### PR TITLE
Change npm service to node

### DIFF
--- a/docs/tutorials/frontend.md
+++ b/docs/tutorials/frontend.md
@@ -59,7 +59,7 @@ Almost there! All our services are installed, but how do we run a command on the
 ```yml
 tooling:
   npm:
-    service: npm
+    service: node
   node:
     service: node
   gulp:


### PR DESCRIPTION
Fixed a little mistake in the documentation, in the tooling section the service for npm says npm, while it should be node

Thank you so much for contributing code to lando!

We will get to your PR as soon as we can but in the meantime you might want to
check to make sure you have done the following. **The more boxes you can check
the easier it will be for us to merge in your changes with confidence**

- [ ] My code passes relevant CI status checks
- [ ] My code includes a test if applicable ([see here](https://docs.devwithlando.io/dev/testing.html))
- [ ] My code includes an update to the `CHANGELOG` ([see here](https://github.com/kalabox/lando/tree/master/docs/changelog))
- [x ] My code includes documentation updates if relevant.
- [ ] I have pinged @pirog/@reynoldsalec/@serundeputy when I think my code is ready for prime time.

If you are unclear about any of the above please add comments below so we can
improve our process.
