### PR TITLE
Added extra ">" in example of updating the ~/.lando/config.yml

### DIFF
--- a/docs/config/config.md
+++ b/docs/config/config.md
@@ -31,5 +31,5 @@ Examples
 ### Turning the proxy off
 
 ```bash
-echo "proxy: 'OFF'" > ~/.lando/config.yml
+echo "proxy: 'OFF'" >> ~/.lando/config.yml
 ```


### PR DESCRIPTION
I changed the example from `echo "proxy: 'OFF'" > ~/.lando/config.yml` to `echo "proxy: 'OFF'" >> ~/.lando/config.yml` so that users wont blow away their entire config if they have one with just the proxy setting.

Now it should append that option to the current config if one is there instead of overwriting it.

Thank you so much for contributing code to lando!

We will get to your PR as soon as we can but in the meantime you might want to
check to make sure you have done the following. **The more boxes you can check
the easier it will be for us to merge in your changes with confidence**

- [ ] My code passes relevant CI status checks
- [x] My code includes a test if applicable ([see here](https://docs.devwithlando.io/dev/testing.html))
- [ ] My code includes an update to the `CHANGELOG` ([see here](https://github.com/kalabox/lando/tree/master/docs/changelog))
- [x] My code includes documentation updates if relevant.
- [ ] I have pinged @pirog/@reynoldsalec/@serundeputy when I think my code is ready for prime time.

If you are unclear about any of the above please add comments below so we can
improve our process.
