### PR TITLE
Add link to get.docker.com for "quick & easy install" of docker on Linux

### DIFF
--- a/docs/installation/installing.md
+++ b/docs/installation/installing.md
@@ -26,7 +26,7 @@ Windows
 Linux
 -----
 
-[1.  Install the [Docker Community Edition](https://docs.docker.com/engine/installation/) for your Linux version. Visit [https://get.docker.com](https://get.docker.com/) for the "quick & easy install" script.**(17.06.1-ce or higher)**
+1.  Install the [Docker Community Edition](https://docs.docker.com/engine/installation/) for your Linux version. Visit [https://get.docker.com](https://get.docker.com/) for the "quick & easy install" script.**(17.06.1-ce or higher)**
 2.  Download the latest `.deb` or `.rpm` package from [GitHub](https://github.com/lando/lando/releases)
 3.  Double-click on the package to launch Software Center
 4.  Click the "Install" button and enter your password when prompted

--- a/docs/installation/installing.md
+++ b/docs/installation/installing.md
@@ -26,7 +26,7 @@ Windows
 Linux
 -----
 
-1.  Install the [Docker Community Edition](https://docs.docker.com/engine/installation/) for your Linux version. **(17.06.1-ce or higher)**
+[1.  Install the [Docker Community Edition](https://docs.docker.com/engine/installation/) for your Linux version. Visit [https://get.docker.com](https://get.docker.com/) for the "quick & easy install" script.**(17.06.1-ce or higher)**
 2.  Download the latest `.deb` or `.rpm` package from [GitHub](https://github.com/lando/lando/releases)
 3.  Double-click on the package to launch Software Center
 4.  Click the "Install" button and enter your password when prompted


### PR DESCRIPTION
I was going to try out Lando and noticed no mention of the fantastic http://get.docker.com site.

The main "Install Docker" documentation is a bit... verbose. I use the get.docker.com script, which "Just Works" on most Linux distros.

Looking forward to testing this out!

====
- [ ] My code passes relevant CI status checks
- [x] My code includes a test if applicable ([see here](https://docs.devwithlando.io/dev/testing.html))
- [ ] My code includes an update to the `CHANGELOG` ([see here](https://github.com/kalabox/lando/tree/master/docs/changelog))
- [ ] My code includes documentation updates if relevant.
- [ ] I have pinged @pirog / @reynoldsalec / @serundeputy when I think my code is ready for prime time.