### PR TITLE
Fix Drupal 6 Accessing services link

### DIFF
--- a/docs/tutorials/drupal6.md
+++ b/docs/tutorials/drupal6.md
@@ -160,7 +160,7 @@ Next Steps
 *   [Adding additional routes](http://docs.devwithlando.io/config/proxy.html)
 *   [Adding additional events](http://docs.devwithlando.io/config/events.html)
 *   [Setting up front end tooling](http://docs.devwithlando.io/tutorials/frontend.html)
-*   [Accessing services (eg your database) from the host](http://docs.devwithlando.io/tutorials/frontend.html)
+*   [Accessing services (eg your database) from the host](http://docs.devwithlando.io/tutorials/access-by-other-devices.html)
 *   [Importing SQL databases](http://docs.devwithlando.io/tutorials/db-import.html)
 *   [Exporting SQL databases](http://docs.devwithlando.io/tutorials/db-export.html)
 *   [Using Composer to Manage a Project](http://docs.devwithlando.io/tutorials/composer-tutorial.html)

--- a/docs/tutorials/drupal6.md
+++ b/docs/tutorials/drupal6.md
@@ -160,7 +160,7 @@ Next Steps
 *   [Adding additional routes](http://docs.devwithlando.io/config/proxy.html)
 *   [Adding additional events](http://docs.devwithlando.io/config/events.html)
 *   [Setting up front end tooling](http://docs.devwithlando.io/tutorials/frontend.html)
-*   [Accessing services (eg your database) from the host](http://docs.devwithlando.io/tutorials/access-by-other-devices.html)
+*   [Accessing services (eg your database) from the host](https://docs.devwithlando.io/tutorials/external-access.html)
 *   [Importing SQL databases](http://docs.devwithlando.io/tutorials/db-import.html)
 *   [Exporting SQL databases](http://docs.devwithlando.io/tutorials/db-export.html)
 *   [Using Composer to Manage a Project](http://docs.devwithlando.io/tutorials/composer-tutorial.html)


### PR DESCRIPTION
The Accessing services (eg your database) from the host is currently pointing to http://docs.devwithlando.io/tutorials/frontend.html instead of https://docs.devwithlando.io/tutorials/access-by-other-devices.html

- [x] My code includes documentation updates if relevant.