### PR TITLE
Closes #545

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -17,6 +17,7 @@ var chalk = require('./node').chalk;
 var os = require('os');
 var path = require('path');
 var Table = require('cli-table');
+var sudoBlock = require('sudo-block');
 
 // Yargonaut must come before yargs
 var yargonaut = require('yargonaut');
@@ -232,6 +233,14 @@ exports.init = function(lando) {
    * });
    */
   return lando.events.emit('pre-cli-load', tasks)
+
+  // No sudo!
+  .then(
+    function() {
+      var message = lando.node.chalk.red('Lando should never be run as root');
+      sudoBlock(message);
+    }
+  )
 
   // Print our result
   .then(function() {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "semver": "^5.4.1",
     "shell-escape": "https://github.com/thinktandem/node-shell-escape/tarball/master",
     "shelljs": "^0.6.0",
+    "sudo-block": "^2.0.0",
     "sync-exec": "^0.6.2",
     "uuid": "^2.0.1",
     "winston": "^2.2.0",


### PR DESCRIPTION
This PR disallows running Lando from the CLI with `sudo` or with elevated privileges on Windows.

Running `sudo lando list` should cause an error message to be thrown and the process to exit. This doesn't work with just plain old `sudo lando` because of the `demandCommand()` call in cli.js. I've made a few attempts to override that and perhaps make use of yargs' `check` function, but I wasn't able to get that to work. We should consider adding more verbose output to give users more info on why this is bad, why they may be trying to do it, and how to fix that, perhaps just a link to docs.