### PR TITLE
Do not map to the conf folder within the named volume

### DIFF
--- a/plugins/lando-services/solr/solr.js
+++ b/plugins/lando-services/solr/solr.js
@@ -121,19 +121,12 @@ module.exports = function(lando) {
       solr.volumes = addConfig(globalConfig, solr.volumes);
 
       // If this is a recent version of solr we need to add to the config as an arg
-      // and also map to the core
       if (!_.includes(['3.6', 4.10], config.version)) {
 
         // Augment the start up command
         var command = solr.command.split(' ');
         command.push('/solrconf');
         solr.command = command.join(' ');
-
-        // Share the config to the core as well
-        var coreConf = path.join(solrConfig.dataDir, core, 'conf');
-        var coreConfig = buildVolume(local, coreConf, '$LANDO_APP_ROOT_BIND');
-        solr.volumes = addConfig(coreConfig, solr.volumes);
-
       }
 
     }

--- a/plugins/lando-services/solr/solr.js
+++ b/plugins/lando-services/solr/solr.js
@@ -10,7 +10,6 @@ module.exports = function(lando) {
 
   // Modules
   var _ = lando.node._;
-  var path = require('path');
 
   var addConfig = lando.services.addConfig;
   //var addScript = lando.services.addScript;


### PR DESCRIPTION
While trying to understand what was going on with #551, I noticed that there was an issue with permissions.

I found out by looking at the code that you are using a named mount possible to persist the solr data, and you are using the solr-precreate script. 

You were also mounting the custom config within the named solr volume, this causing a bit of a permissions issue as I noted on #551.

You really don't need to map the custom config within the named volume as that's taken care by the solr-precreate command.

- [x] My code passes relevant CI status checks
- [ ] My code includes a test if applicable ([see here](https://docs.devwithlando.io/dev/testing.html))
- [ ] My code includes an update to the `CHANGELOG` ([see here](https://github.com/kalabox/lando/tree/master/docs/changelog))
- [ ] My code includes documentation updates if relevant.
- [x] I have pinged @pirog/@reynoldsalec/@serundeputy when I think my code is ready for prime time.
