### PR TITLE
thinktandem/horoscope#197: Adding metrics for lando share command.

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -41,7 +41,7 @@ var getClient = function(id) {
 };
 
 /*
- * Get the metrics ID for this kalabox instance.
+ * Get the metrics ID for this lando instance.
  */
 var getId = function() {
 
@@ -123,7 +123,7 @@ var report = function(data) {
         data.devMode = false;
         // Add lando version information.
         data.version = config.version;
-        // Add operation system information.
+        // Add operating system information.
         data.os = config.os;
       },
 

--- a/plugins/lando-core/lib/tasks/share.js
+++ b/plugins/lando-core/lib/tasks/share.js
@@ -54,6 +54,11 @@ module.exports = function(lando) {
             }
           })
 
+          .then(function(app) {
+            // Report lando share use to metrics
+            return lando.metrics.reportAction('share', {app: app});
+          })
+
           // Get the URLS
           .then(function() {
 
@@ -109,9 +114,6 @@ module.exports = function(lando) {
               process.stdin.on('data', function() {
                 tunnel.close();
               });
-
-              // Report lando share use to metrics
-              lando.metrics.reportAction('share', {app: app});
 
             });
 

--- a/plugins/lando-core/lib/tasks/share.js
+++ b/plugins/lando-core/lib/tasks/share.js
@@ -110,6 +110,9 @@ module.exports = function(lando) {
                 tunnel.close();
               });
 
+              // Report lando share use to metrics
+              lando.metrics.reportAction('share', {app: app});
+
             });
 
             tunnel.on('close', function() {


### PR DESCRIPTION
@pirog I was able to add the metrics call to `reportAction()` to `share.js` where the `app` object was/is available.