### PR TITLE
Fix bats test command documentation

### DIFF
--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -35,7 +35,7 @@ The installer tests use the [BATS framework](https://github.com/sstephenson/bats
 > If you run these tests on a machine that already has Lando installed it is most likely going to wipe away your currently installed version of Lando. For that reason please **BE CAREFUL USING THIS!!!**
 
 ```bash
-grunt bats
+grunt test:bats
 ```
 
 Writing Tests


### PR DESCRIPTION
The documentation to run bats tests is wrong, fix attached.

- [x] My code passes relevant CI status checks
- [ ] My code includes a test if applicable ([see here](https://docs.devwithlando.io/dev/testing.html))
- [ ] My code includes an update to the `CHANGELOG` ([see here](https://github.com/kalabox/lando/tree/master/docs/changelog))
- [x] My code includes documentation updates if relevant.
- [x] I have pinged @pirog/@reynoldsalec/@serundeputy when I think my code is ready for prime time.
  