### PR TITLE
Make aversion of destruction the default action

### DIFF
--- a/plugins/lando-core/lib/tasks/destroy.js
+++ b/plugins/lando-core/lib/tasks/destroy.js
@@ -19,7 +19,7 @@ module.exports = function(lando) {
       yes: {
         describe: 'Auto answer yes to prompts',
         alias: ['y'],
-        default: false,
+        default: 'n',
         boolean: true,
         interactive: {
           type: 'confirm',


### PR DESCRIPTION
I don't think this code change actually works; just hoping to spark conversation about the merits of averting destruction by default (currently, pressing `<enter>` results in total descruction).