### PR TITLE
Update Drush Launcher to 0.5.1

### DIFF
--- a/plugins/lando-recipes/recipes/drupal7/drupal7.js
+++ b/plugins/lando-recipes/recipes/drupal7/drupal7.js
@@ -15,7 +15,7 @@ module.exports = function(lando) {
   // "Constants"
   var DRUSH8 = '8.1.15';
   var DRUSH7 = '7.4.0';
-  var DRUSHLAUNCHER = '0.4.3';
+  var DRUSHLAUNCHER = '0.5.1';
 
   /**
    * Helper to get DRUSH 8 or DRUSH LAUNCHER phar


### PR DESCRIPTION
- [ ] My code passes relevant CI status checks
- [ ] My code includes a test if applicable ([see here](https://docs.devwithlando.io/dev/testing.html))
- [ ] My code includes an update to the `CHANGELOG` ([see here](https://github.com/kalabox/lando/tree/master/docs/changelog))
- [ ] My code includes documentation updates if relevant.

Didn't go through any of the above because I don't know what I'm doing (I really don't) and couldn't find the Drush Launcher version anywhere else in files so even though there's `drupal7` in the filename it seems it's there we should update the launcher version. Please just iterate over this PR where it's required.

This PR is for #666 
