### PR TITLE
Fix docs typo started.md

### DIFF
--- a/docs/started.md
+++ b/docs/started.md
@@ -107,6 +107,6 @@ touch .lando.yml
 vi .lando.yml
 ```
 
-Here is a good example of a generic LENO stack `.lando.yml`
+Here is a good example of a generic LEMP stack `.lando.yml`
 
 {% codesnippet "./../examples/lemp2/.lando.yml" %}{% endcodesnippet %}


### PR DESCRIPTION
Fix a typo in docs `started.md` file, **_LEMP_** stack was written **_LENO_** stack.