### PR TITLE
Document lamp appserver `via` option on recipe tut

### DIFF
--- a/examples/lamp2/.lando.yml
+++ b/examples/lamp2/.lando.yml
@@ -15,6 +15,10 @@ config:
   # NOTE: that this needs to be wrapped in quotes so that it is a string
   php: '5.6'
 
+  # Serve php by either apache or nginx. You can put in any `service:version`
+  # string that is supported by Lando's nginx and apache services.
+  via: nginx
+
   # Optionally specify the location of the webroot relative to your approot.
   #
   # If ommitted this will be your approot itself.


### PR DESCRIPTION
Just a small change to docs; no code changes.

This is already in the `lamp` example, but this is the example recipe that shows up on /tutorials/lamp.html, where I went looking for it.