### PR TITLE
Fix lando pull bug on pantheon wordpress sites 

### DIFF
--- a/docs/changelog/2018.md
+++ b/docs/changelog/2018.md
@@ -19,6 +19,7 @@ v3.0.0-beta.37 - In Development
 * Switched to all the `yarn` [#639](https://github.com/lando/lando/issues/639)
 * Updated `drush launcher` to version `0.5.1` [#666](https://github.com/lando/lando/issues/666)
 * Updated docs to reflect new refactor, dx and governance. [#685](https://github.com/lando/lando/issues/685)
+* Fixed bug where `lando pull` fails to replace wordpress URLs in db [#711](https://github.com/lando/lando/issues/711)
 * Updated `terminus` to version `1.7.0`
 
 v3.0.0-beta.35 - [January 8, 2018](https://github.com/lando/lando/releases/tag/v3.0.0-beta.35)

--- a/plugins/lando-recipes/recipes/pantheon/pull.sh
+++ b/plugins/lando-recipes/recipes/pantheon/pull.sh
@@ -169,7 +169,7 @@ if [ "$DATABASE" != "none" ]; then
   # Do some post DB things on WP
   if [ "$FRAMEWORK" == "wordpress" ]; then
     echo "Doing the ole post-migration search-replace on WordPress..."
-    wp search-replace "http://$ENV-$SITE.pantheonsite.io" "http://$LANDO_APP_NAME.lndo.site"
+    wp search-replace --path="$LANDO_WEBROOT" "http://$ENV-$SITE.pantheonsite.io" "http://$LANDO_APP_NAME.lndo.site"
   fi
 
 fi


### PR DESCRIPTION
Fixes #711.

If wordpress files are not in the root directory `lando pull` will throw error. When the `wp search-replace` command fires the following error message appears:
> Error: This does not seem to be a WordPress install.
> Pass --path=`path/to/wordpress` or run `wp core download`.

---

- [x] My code passes relevant CI status checks
- [x] My code includes a test if applicable ([see here](https://docs.devwithlando.io/dev/testing.html))
- [x] My code includes an update to the `CHANGELOG` ([see here](https://github.com/kalabox/lando/tree/master/docs/changelog))
- [x] My code includes documentation updates if relevant.
- [x] I have pinged [a project committer](https://docs.devwithlando.io/contrib/committer.html) when I think my code is ready for prime time.

