### PR TITLE
Closes #647 - Allow Remote Docker

### DIFF
--- a/bin/lando.js
+++ b/bin/lando.js
@@ -23,7 +23,7 @@ var userConfRoot = path.join(os.homedir(), '.lando');
 var version = require(path.join(__dirname, '..', 'package.json')).version;
 
 // Allow envvars to override a few core things
-var ENVPREFIX = process.env.LANDO_CORE_ENVPREFIX || 'LANDO_';
+var ENVPREFIX = process.env.LANDO_CORE_ENVPREFIX || 'LANDO';
 var LOGLEVELCONSOLE = process.env.LANDO_CORE_LOGLEVELCONSOLE || 'warn';
 var USERCONFROOT = process.env.LANDO_CORE_USERCONFROOT || userConfRoot;
 

--- a/docs/changelog/2018.md
+++ b/docs/changelog/2018.md
@@ -14,6 +14,7 @@ v3.0.0-beta.37 - In Development
 * Fixed bug where offline mode was failing on metrics check [#630](https://github.com/lando/lando/issues/630)
 * Fixed bug where `php 5.3 apache` was not starting correctly [#652](https://github.com/lando/lando/issues/652)
 * Fixed GitHub API rate limit bug [#598](https://github.com/lando/lando/issues/598)
+* Improved overriding of global config through envvars [#647](https://github.com/lando/lando/issues/647)
 * Provided some corrective action around `proxy` start failures [#632](https://github.com/lando/lando/issues/632)
 * Refactored the code to increase testibility and reduce complexity and dependents [#620](https://github.com/lando/lando/issues/620)
 * Removed dependency on `grunt` [#639](https://github.com/lando/lando/issues/639)

--- a/docs/config/config.md
+++ b/docs/config/config.md
@@ -23,10 +23,17 @@ This file specifies the core configuration options for Lando. Lando will scan a 
 
 Note that overrides will be merged in with the last value in `configSources` taking priority. Also note that there are some configuration options **THAT MUST** be set during the bootstrap of the `lando` object. For more information about how to bootstrap your own custom `lando` object please consult the [API docs](./../api/api.html#lando).
 
+Environment Variables
+---------------------
+
+You can also override any global config value using environment variables of the form `envPrefix_config_value`. So to change the `mode` you'd set `LANDO_MODE=mymode`. For more complex config (eg an object or array) you can set the envvar to a `JSON` string. Also note that Lando keys that are camelCase will be separated as envvars with `_`. For example `engineConfig` will be accessible vis `LANDO_ENGINE_CONFIG`.
+
+> #### Hint::What is my `envPrefix`
+>
+> BY default this is `LANDO` but you can run `lando config` and look at the `envPrefix` key to discover yours.
+
 Examples
 --------
-
-These examples assume you have a config source at `~/.lando/config.yml`
 
 ### Turning the proxy off
 
@@ -63,4 +70,42 @@ logLevelConsole: silly
 # Load additional custom plugins
 plugins:
   - lando-my-plugin
+```
+
+### Set a config value through an ENVVAR
+
+This assumes you are using `LANDO` as the `envPrefix`.
+
+```bash
+# Check the current config value for mode
+lando config | grep mode
+// "mode": "cli",
+
+// Override with an envvar
+export LANDO_MODE=mymode
+
+# Check the new value
+lando config | grep mode
+// "mode": "mymode",
+```
+
+### Set complicated config through an ENVVAR
+
+```bash
+# Check the current engine config
+lando config
+// "engineConfig": {
+//   "host": "127.0.0.1",
+//   "socketPath": "/var/run/docker.sock"
+// },
+
+// Override with an envvar
+export LANDO_ENGINE_CONFIG='{"host": "localhost"}'
+
+# Check the new value
+lando config
+// "engineConfig": {
+//   "host": "localhost",
+//   "socketPath": "/var/run/docker.sock"
+// },
 ```

--- a/lib/config.js
+++ b/lib/config.js
@@ -6,7 +6,6 @@ var fs = require('fs-extra');
 var os = require('os');
 var path = require('path');
 var yaml = require('js-yaml');
-var _config = this;
 
 /*
  * Document
@@ -45,6 +44,17 @@ var processType = function() {
   // If any of the above are true return the type
   return (isElectron || isChrome || isAtom) ? 'browser' : 'node';
 
+};
+
+/*
+ * Document
+ */
+exports.tryConvertJson = function(value) {
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    return value;
+  }
 };
 
 /**
@@ -106,17 +116,9 @@ exports.updatePath = function(dir) {
  * process.env = config.stripEnv('LANDO_');
  */
 exports.stripEnv = function(prefix) {
-
-  // Strip it down
-  _.each(process.env, function(value, key) {
-    if (_.includes(key, prefix)) {
-      delete process.env[key];
-    }
-  });
-
-  // Return
-  return process.env;
-
+  return _(process.env)
+    // Remove prefix vars
+    .omitBy((value, key) => _.includes(key, prefix)).value();
 };
 
 /**
@@ -201,7 +203,7 @@ exports.loadFiles = function(files) {
   // has precedent
   _.forEach(files, function(file) {
     if (fs.pathExistsSync(file)) {
-      conf = _config.merge(conf, yaml.safeLoad(fs.readFileSync(file)));
+      conf = exports.merge(conf, yaml.safeLoad(fs.readFileSync(file)));
     }
   });
 
@@ -211,24 +213,21 @@ exports.loadFiles = function(files) {
 };
 
 /**
- * Grab envvars and map to config
+ * Filter process.env by a given prefix
  *
  * @since 3.0.0
  * @alias 'lando.utils.config.loadEnvs'
+ * @param {String} prefix - The prefix by which to filter. Should be without the trailing `_` eg `LANDO` not `LANDO_`
+ * @returns {Object} Object of things with camelCased keys
  */
 exports.loadEnvs = function(prefix) {
-
-  // Start an object of our env
-  var envConfig = {};
-
-  // Build object of lando_ envvars
-  _.forEach(process.env, function(value, key) {
-    if (_.includes(key, prefix)) {
-      envConfig[_.camelCase(_.trimStart(key, prefix))] = value;
-    }
-  });
-
-  // Return our findings
-  return envConfig;
-
+  return _(process.env)
+    // Only muck with prefix_ variables
+    .pickBy((value, key) => _.includes(key, prefix))
+    // Prep the keys for consumption
+    .mapKeys((value, key) => _.camelCase(_.trimStart(key, prefix)))
+    // If we have a JSON string as a value, parse that and assign its sub-keys
+    .mapValues(exports.tryConvertJson)
+    // Resolve the lodash wrapper
+    .value();
 };

--- a/plugins/lando-engine/lib/env.js
+++ b/plugins/lando-engine/lib/env.js
@@ -4,24 +4,32 @@
 var path = require('path');
 
 /*
- * Helper to get default engine config
+ * Helper to get engine config
  */
 exports.getEngineConfig = function() {
 
   // Create the default options
-  var config = {
+  const defaultConfig = {
     host: '127.0.0.1',
     socketPath: '/var/run/docker.sock'
   };
 
   // Slight deviation on Windows due to npipe://
   if (process.platform === 'win32') {
-    config.socketPath = '//./pipe/docker_engine';
+    defaultConfig.socketPath = '//./pipe/docker_engine';
   }
 
-  // Return the config
-  return config;
+  let finalConfig = defaultConfig;
 
+  // Allow mixin of environment variables
+  if (process.env.engineConfig && JSON.parse(process.env.engineConfig)) {
+    finalConfig = Object.assign(
+      defaultConfig,
+      JSON.parse(process.env.engineConfig)
+    );
+  }
+
+  return finalConfig;
 };
 
 /*

--- a/plugins/lando-engine/lib/env.js
+++ b/plugins/lando-engine/lib/env.js
@@ -4,32 +4,23 @@
 var path = require('path');
 
 /*
- * Helper to get engine config
+ * Helper to get default engine config
  */
 exports.getEngineConfig = function() {
 
   // Create the default options
-  const defaultConfig = {
+  const config = {
     host: '127.0.0.1',
     socketPath: '/var/run/docker.sock'
   };
 
   // Slight deviation on Windows due to npipe://
   if (process.platform === 'win32') {
-    defaultConfig.socketPath = '//./pipe/docker_engine';
+    config.socketPath = '//./pipe/docker_engine';
   }
 
-  let finalConfig = defaultConfig;
+  return config;
 
-  // Allow mixin of environment variables
-  if (process.env.engineConfig && JSON.parse(process.env.engineConfig)) {
-    finalConfig = Object.assign(
-      defaultConfig,
-      JSON.parse(process.env.engineConfig)
-    );
-  }
-
-  return finalConfig;
 };
 
 /*

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -1,0 +1,97 @@
+/**
+* Tests for config system.
+* @file config.spec.js
+*/
+'use strict';
+
+// Setup chai.
+const chai = require('chai');
+const expect = chai.expect;
+chai.should();
+
+// Get caching module to test
+const config = require('./../lib/config');
+
+// This is the file we are testing
+describe('config', function() {
+
+  describe('#tryConvertJson', function() {
+
+    it('returns the unaltered input if input is not a parsable JSON string', function() {
+
+      // Input value
+      const input = 'obiwan';
+
+      // Get the result of a JSON parse
+      const result = config.tryConvertJson(input);
+
+      // What were you expecting?
+      expect(result).to.be.a('string');
+      expect(result).to.equal(input);
+
+    });
+
+    // NOTE: means the JSON string is enclosed by {}
+    it('returns an object if input is a parsable JSON string representing an object', function() {
+
+      // Input value
+      const input = '{}';
+
+      // Get the result of a JSON parse
+      const result = config.tryConvertJson(input);
+
+      // What were you expecting?
+      expect(result).to.be.an('object');
+
+    });
+
+    // NOTE: means the JSON string is enclosed by []
+    it('returns an array if input is a parsable JSON string representing an array', function() {
+
+      // Input value
+      const input = '[]';
+
+      // Get the result of a JSON parse
+      const result = config.tryConvertJson(input);
+
+      // What were you expecting?
+      expect(result).to.be.an('array');
+
+    });
+
+  });
+
+  describe('#loadEnvs', function() {
+
+    it('returns an object built from all keys from process.env that start with a given prefix', function() {
+
+      // Add mock data to process.env
+      process.env.DANCE_NOW = 'everybody';
+
+      const result = config.loadEnvs('DANCE');
+
+      expect(result).to.be.an('object');
+      expect(result).to.have.key('now');
+      expect(result.now).to.equal(process.env.DANCE_NOW);
+
+    });
+
+  });
+
+  describe('#stripEnvs', function() {
+
+    it('returns process.env object stripped of all keys that start with prefix', function() {
+
+      // Add mock data to process.env
+      process.env.DANCE_NOW = 'everybody';
+
+      const result = config.stripEnv('DANCE');
+
+      expect(result).to.be.an('object');
+      expect(result).to.not.have.key('DANCE_NOW');
+
+    });
+
+  });
+
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -108,13 +108,13 @@ ansi-green@^0.1.1:
   dependencies:
     ansi-wrap "0.1.0"
 
-ansi-regex@*, ansi-regex@^3.0.0, ansi-regex@~3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
-
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
+
+ansi-regex@^3.0.0, ansi-regex@~3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -841,7 +841,7 @@ debug@3.1.0, debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
 
@@ -1814,7 +1814,7 @@ import-lazy@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
@@ -2300,10 +2300,6 @@ lockfile@~1.0.1, lockfile@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/lockfile/-/lockfile-1.0.3.tgz#2638fc39a0331e9cac1a04b71799931c9c50df79"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -2311,27 +2307,9 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
 
 lodash._root@~3.0.0:
   version "3.0.1"
@@ -2364,10 +2342,6 @@ lodash.padstart@^4.1.0:
 lodash.pick@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
 lodash.union@~4.6.0:
   version "4.6.0"
@@ -3418,7 +3392,7 @@ readable-stream@~2.1.5:
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   dependencies:
@@ -4325,7 +4299,7 @@ uuid@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 
-validate-npm-package-license@*, validate-npm-package-license@^3.0.1, validate-npm-package-license@~3.0.1:
+validate-npm-package-license@^3.0.1, validate-npm-package-license@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz#2804babe712ad3379459acfbe24746ab2c303fbc"
   dependencies:


### PR DESCRIPTION
This should allow folks to use Lando in environments like CircleCI where the Docker daemon is running on a remote server. The injected env var needs to be a JSON string for this to work. I can add docs too before we merge. @pirog thoughts on this? I wanted to add a test to this too, but pending the merge of some other test code, I didn't want to muck with duplicating stuff.

- [x] My code passes relevant CI status checks
- [x] I have pinged [a project committer](https://docs.devwithlando.io/contrib/committer.html) when I think my code is ready for prime time.
- [x] My code includes a test if applicable ([see here](https://docs.devwithlando.io/dev/testing.html))
