### PR TITLE
[docs] Fix links to Advanced Service Configuration and Committers

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ the easier it will be for us to merge in your changes with confidence**
 - [ ] My code includes a test if applicable ([see here](https://docs.devwithlando.io/dev/testing.html))
 - [ ] My code includes an update to the `CHANGELOG` ([see here](https://github.com/kalabox/lando/tree/master/docs/changelog))
 - [ ] My code includes documentation updates if relevant.
-- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/committer.html) when I think my code is ready for prime time.
+- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.
 
 If you are unclear about any of the above please add comments below so we can
 improve our process.

--- a/docs/config/build.md
+++ b/docs/config/build.md
@@ -19,7 +19,7 @@ services:
 Steps Run As Root
 ----------------
 
-If you do not want to use your own custom image or Dockerfile via [Advanced Service Configuration](./overrides.md), we let you do some extra service construction steps after each service is started.
+If you do not want to use your own custom image or Dockerfile via [Advanced Service Configuration](./advanced.md), we let you do some extra service construction steps after each service is started.
 
 **Please note** that these steps must make sense within the context of the container you are running them in. For example, you will not be able to run `dnf` inside of a `debian` flavored container.
 

--- a/docs/dev/services.md
+++ b/docs/dev/services.md
@@ -90,7 +90,7 @@ module.exports = function(lando) {
 
 ### versions
 
-The versions array is a list of the docker tags for the docker image you've chosen to use as the basis of your service. It is a common convention to add in two special tags `latest` and `custom`.  `latest` will need to be a valid docker tag (it usually exists by default). `custom` will tell Lando that the image is provided downstream in the [advanced service configuration](./../config/overrides.md).
+The versions array is a list of the docker tags for the docker image you've chosen to use as the basis of your service. It is a common convention to add in two special tags `latest` and `custom`.  `latest` will need to be a valid docker tag (it usually exists by default). `custom` will tell Lando that the image is provided downstream in the [advanced service configuration](./../config/advanced.md).
 
 ```js
 /*


### PR DESCRIPTION
Some links to Advanced Service Configuration in the docs are broken. For example, see:

- https://docs.devwithlando.io/config/build.html
- https://docs.devwithlando.io/dev/services.html

----
- ~[ ] My code passes relevant CI status checks~ N/A
- ~[ ] My code includes a test if applicable ([see here](https://docs.devwithlando.io/dev/testing.html))~ N/A
- ~[ ] My code includes an update to the `CHANGELOG` ([see here](https://github.com/kalabox/lando/tree/master/docs/changelog))~ N/A
- [X] My code includes documentation updates if relevant.
- [x] I have pinged [a project committer](https://docs.devwithlando.io/contrib/committer.html) when I think my code is ready for prime time.
