### PR TITLE
Checked if cmd is an array and wrap in array literal if not so we can…

### DIFF
--- a/docs/changelog/2018.md
+++ b/docs/changelog/2018.md
@@ -20,6 +20,7 @@ v3.0.0-beta.37 - In Development
 * Updated `drush launcher` to version `0.5.1` [#666](https://github.com/lando/lando/issues/666)
 * Updated docs to reflect new refactor, dx and governance. [#685](https://github.com/lando/lando/issues/685)
 * Updated `terminus` to version `1.7.0`
+* Fixed bug where cmd string would have concat run with an array causing an error. [#767](https://github.com/lando/lando/issues/767) 
 
 v3.0.0-beta.35 - [January 8, 2018](https://github.com/lando/lando/releases/tag/v3.0.0-beta.35)
 ----------------------------------

--- a/plugins/lando-tooling/tooling.js
+++ b/plugins/lando-tooling/tooling.js
@@ -90,7 +90,8 @@ module.exports = function(lando) {
         }
 
         // Start with the entrypoint
-        var cmd = config.cmd || [config.name];
+        //  Check if cmd is an array and wrap in array literal if not so we can concat with other commands.
+        var cmd = Array.isArray(config.cmd) ? config.cmd : [config.cmd] || [config.name];
 
         // Add in args if we expect them
         if (lando.config.process === 'node') {


### PR DESCRIPTION
Check if cmd is an array and wrap in an array literal if not so we can concat with other commands.

- [x] My code passes relevant CI status checks
- N/A [ ] My code includes a test if applicable ([see here](https://docs.devwithlando.io/dev/testing.html))
- [x] My code includes an update to the `CHANGELOG` ([see here](https://github.com/kalabox/lando/tree/master/docs/changelog))
- N/A [ ] My code includes documentation updates if relevant.
- [x] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

