### PR TITLE
Fix download URL in CI docs

### DIFF
--- a/docs/tutorials/lando-and-ci.md
+++ b/docs/tutorials/lando-and-ci.md
@@ -59,6 +59,11 @@ Here is a `.travis.yml` file that accomplishes the above for our current example
 
 {% codesnippet "./../examples/lando-and-ci/.travis.yml" %}{% endcodesnippet %}
 
+> #### Warning::This Lando download is bleeding edge
+>
+> If you need a stable Lando release, it's best to peg your version to an
+> [official release](https://github.com/lando/lando/releases).
+
 That's great! More importantly though now each time we file a PR against the GitHub repo it will:
 
 *   Spin up a Travis CI environment

--- a/examples/lando-and-ci/.travis.yml
+++ b/examples/lando-and-ci/.travis.yml
@@ -12,7 +12,7 @@ services:
 before_install:
   - sudo apt-get -y update
   - sudo apt-get -y install cgroup-bin curl
-  - curl -fsSL -o /tmp/lando-latest.deb http://installer.lando.io/lando-latest-dev.deb
+  - curl -fsSL -o /tmp/lando-latest.deb http://installer.kalabox.io/lando-latest-dev.deb
   - sudo dpkg -i /tmp/lando-latest.deb
   - lando version
 


### PR DESCRIPTION
Just updating the documented latest dev download URL.

- [ ] My code passes relevant CI status checks
- [ ] My code includes a test if applicable ([see here](https://docs.devwithlando.io/dev/testing.html))
- [ ] My code includes an update to the `CHANGELOG` ([see here](https://github.com/kalabox/lando/tree/master/docs/changelog))
- [x] My code includes documentation updates if relevant.
- [x] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.
