### PR TITLE
#626 - Add tutorial for XDebug in VS Code

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -103,6 +103,7 @@
 *   [Setting up Additional Tooling](tutorials/setup-additional-tooling.md)
 *   [Setting up Additional Routes](config/proxy.md)
 *   [Setting up Additional Events](config/events.md)
+*   [Using Lando in Visual Studio Code](tutorials/lando-with-vscode.md)
 *   [Using NodeJS Frontend Tooling](tutorials/frontend.md)
 *   [Accessing Your Services Externally](tutorials/external-access.md)
 *   [Accessing Lando from Other Devices](tutorials/access-by-other-devices.md)

--- a/docs/services/php.md
+++ b/docs/services/php.md
@@ -123,7 +123,11 @@ You will need to rebuild your app with `lando rebuild` to apply the changes to t
 Using Xdebug
 ------------
 
-You can activate `xdebug` for remote debugging by setting `xdebug: true` in the config for your `php` service. This will enable `xdebug` and configure it so you can connect from your host machine. You will need to configure your IDE so that it can connect. Here is some example config for [ATOM's](https://atom.io/) [`php-debug`](https://github.com/gwomacks/php-debug) plugin:
+You can activate `xdebug` for remote debugging by setting `xdebug: true` in the config for your `php` service. This will enable `xdebug` and configure it so you can connect from your host machine. You will need to configure your IDE so that it can connect.
+
+Here are the instructions to [setup XDebug in Visual Studio Code](tutorials/lando-with-vscode.md).
+
+Here is some example config for [ATOM's](https://atom.io/) [`php-debug`](https://github.com/gwomacks/php-debug) plugin:
 
 ```
 "php-debug":

--- a/docs/tutorials/lando-with-vscode.md
+++ b/docs/tutorials/lando-with-vscode.md
@@ -1,0 +1,103 @@
+Using Lando with VS Code
+========================
+
+[Visual Studio Code](https://github.com/Microsoft/vscode/) is a great open source editor for programming. 
+It is however not so easy to debug PHP applications - especially when they're run inside Docker containers, like Lando.
+
+This is a basic setup to help you in this task.
+
+<!-- toc -->
+
+Getting Started
+---------------
+
+Enable XDebug by adding some lines to your Lando recipe.
+
+```yaml
+# Enable XDebug in your .lando.yml
+name: mywebsite
+recipe: drupal8
+config:
+  webroot: docroot
+  xdebug: true
+  conf: 
+    # Tell Lando to use additional PHP settings.
+    # The location of this file is arbitrary. 
+    # We placed it inside .vscode/ folder simply because we find it convenient.
+    php: .vscode/php.ini
+```
+
+Create the custom `php.ini` file to add XDebug settings to PHP.
+
+```bash
+touch .vscode/php.ini
+code .vscode/php.ini
+```
+
+Add your custom XDebug settings.
+
+```ini
+[PHP]
+
+;;;;;;;;;;;;;;;
+;IMPORTANT;
+;PLACE THIS FILE UNDER .vscode folder;
+;SO IT DOESNT GET COMMITTED;
+;;;;;;;;;;;;;;;
+
+; Xdebug
+xdebug.max_nesting_level = 256
+xdebug.show_exception_trace = 0
+xdebug.collect_params = 0
+# Extra custom Xdebug setting for debug to work in VSCode.
+xdebug.remote_enable = 1 
+xdebug.remote_autostart = 1 
+```
+
+Rebuild your environment.
+
+```bash
+lando rebuild
+```
+
+Finally, you need a custom `launch.json` file in VS Code in order to map paths so that XDebug works correctly.
+
+```bash
+touch .vscode/launch.json
+code .vscode/launch.json
+```
+
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "XDebug",
+      "type": "php",
+      "request": "launch",
+      "port": 9000,
+      "log": true,
+      // We used to do this in previous versions of VS Code:
+      // "localSourceRoot": "${workspaceRoot}/",
+      // "serverSourceRoot": "/app/",
+      //
+      // But this has been deprecated and we now use this:
+      "pathMappings": {
+        "/app/": "${workspaceRoot}/",
+      }
+    }
+  ]
+}
+```
+
+Done! 
+
+You can now click start debugging (type F5 or click on the icon in the left sidebar).
+
+
+Read More
+---------
+
+*   [Original Gist with settings for XDebug in VS Code](https://gist.github.com/MatthieuScarset/0c3860def9ff1f0b84e32f618c740655)
+*   [PHP programming in VS code](https://code.visualstudio.com/docs/languages/php)
+


### PR DESCRIPTION
- [X] My code includes documentation updates if relevant.
- [ ] My code includes an update to the `CHANGELOG`

I have added a new page under tutorials to explain how to get XDebug working with Lando in VS Code. 

I would like to update the CHANGELOG but I was not sure how to edit this file actually.