### PR TITLE
Fix typo in mysql lando example file

### DIFF
--- a/examples/mysql/.lando.yml
+++ b/examples/mysql/.lando.yml
@@ -26,7 +26,7 @@ services:
     # This port will change every time you restart this app
     #
     # You can also set this to a static port you want to use `portforward:3311`.
-    # You will need to make sure the port is open and avialable
+    # You will need to make sure the port is open and available
     portforward: true
 
     # Optionally change the default db credentials


### PR DESCRIPTION
This fixes a very minor typo in the mysql `.lando.yml` file: `avialable` -> `available`.