### PR TITLE
Be more specific about .env file name

### DIFF
--- a/docs/config/env.md
+++ b/docs/config/env.md
@@ -41,7 +41,7 @@ LANDO_WEBROOT_GID=33
 
 ### Environment File
 
-If you drop a `.env` file into the root directory of your app Lando will automatically inject the variables into all of your services. This is particularly useful if you want
+If you drop a file named `.env` into the root directory of your app Lando will automatically inject the variables into all of your services. This is particularly useful if you want
 
 1. To inject sensitive credentials into the environment (a la the 12-factor app model)
 2. Store credentials in a `.gitignored` file that is not committed to the repo


### PR DESCRIPTION
In the existing wording, it sounds like you could drop any `.env` file into your app root to have it parsed. In reality, the file must be named exactly `.env`. By comparison, if I were to say you could drop a `.yml` file into your app to have it parsed, you probably wouldn't think to name the file `.yml` but rather that any .yml would be parsed.