### PR TITLE
Default MySQL to 5.7, add support for service default versions.

### DIFF
--- a/docs/changelog/2018.md
+++ b/docs/changelog/2018.md
@@ -1,3 +1,12 @@
+v3.0.0-beta.41 - [April 24, 2018](https://github.com/lando/lando/releases/tag/v3.0.0-beta.41)
+--------------------------------
+
+**SERIOUSLY, READ THE DOCS!: https://docs.devwithlando.io/**
+
+* Set a Default MySQL version (5.7) [#908](https://github.com/lando/lando/issues/908)
+* Convert interactive name parameters to machine safe (5.7) [#891](https://github.com/lando/lando/issues/891)
+
+
 v3.0.0-beta.40 - [April 8, 2018](https://github.com/lando/lando/releases/tag/v3.0.0-beta.40)
 --------------------------------
 

--- a/docs/changelog/2018.md
+++ b/docs/changelog/2018.md
@@ -4,7 +4,7 @@ v3.0.0-beta.41 - [April 24, 2018](https://github.com/lando/lando/releases/tag/v3
 **SERIOUSLY, READ THE DOCS!: https://docs.devwithlando.io/**
 
 * Set a Default MySQL version (5.7) [#908](https://github.com/lando/lando/issues/908)
-* Convert interactive name parameters to machine safe (5.7) [#891](https://github.com/lando/lando/issues/891)
+* Convert interactive name parameters to machine safe [#891](https://github.com/lando/lando/issues/891)
 
 
 v3.0.0-beta.40 - [April 8, 2018](https://github.com/lando/lando/releases/tag/v3.0.0-beta.40)

--- a/docs/changelog/2018.md
+++ b/docs/changelog/2018.md
@@ -3,9 +3,8 @@ v3.0.0-beta.41 - [April 24, 2018](https://github.com/lando/lando/releases/tag/v3
 
 **SERIOUSLY, READ THE DOCS!: https://docs.devwithlando.io/**
 
-* Set a Default MySQL version (5.7) [#908](https://github.com/lando/lando/issues/908)
+* Set default service versions [#908](https://github.com/lando/lando/issues/908)
 * Convert interactive name parameters to machine safe [#891](https://github.com/lando/lando/issues/891)
-
 
 v3.0.0-beta.40 - [April 8, 2018](https://github.com/lando/lando/releases/tag/v3.0.0-beta.40)
 --------------------------------

--- a/docs/services/apache.md
+++ b/docs/services/apache.md
@@ -6,9 +6,8 @@ Apache
 Supported versions
 ------------------
 
-*   [2.4](https://hub.docker.com/r/_/httpd/)
+*   **[2.4](https://hub.docker.com/r/_/httpd/)** **(defualt)**
 *   [2.2](https://hub.docker.com/r/_/httpd/)
-*   [latest](https://hub.docker.com/r/_/httpd/)
 *   custom
 
 Example

--- a/docs/services/dotnet.md
+++ b/docs/services/dotnet.md
@@ -7,11 +7,10 @@ Supported versions
 ------------------
 
 *   [2](https://hub.docker.com/r/microsoft/dotnet/)
-*   [2.0](https://hub.docker.com/r/microsoft/dotnet/)
+*   **[2.0](https://hub.docker.com/r/microsoft/dotnet/)** **(default)**
 *   [1](https://hub.docker.com/r/microsoft/dotnet/)
 *   [1.1](https://hub.docker.com/r/microsoft/dotnet/)
 *   [1.0](https://hub.docker.com/r/microsoft/dotnet/)
-*   [latest](https://hub.docker.com/r/microsoft/dotnet/)
 *   custom
 
 Example

--- a/docs/services/elasticsearch.md
+++ b/docs/services/elasticsearch.md
@@ -6,12 +6,11 @@ Elasticsearch
 Supported versions
 ------------------
 
-*   [5.5](https://hub.docker.com/r/itzg/elasticsearch/)
+*   **[5.5](https://hub.docker.com/r/itzg/elasticsearch/)** **(default)**
 *   [5.4](https://hub.docker.com/r/itzg/elasticsearch/)
 *   [5.3](https://hub.docker.com/r/itzg/elasticsearch/)
 *   [5.2](https://hub.docker.com/r/itzg/elasticsearch/)
 *   [5.1](https://hub.docker.com/r/itzg/elasticsearch/)
-*   [latest](https://hub.docker.com/r/itzg/elasticsearch/)
 *   custom
 
 Example

--- a/docs/services/go.md
+++ b/docs/services/go.md
@@ -7,8 +7,7 @@ Supported versions
 ------------------
 
 *   [1.8.4](https://hub.docker.com/r/_golang/)
-*   [1.8](https://hub.docker.com/r/_golang/)
-*   [latest](https://hub.docker.com/r/_/_golang/)
+*   **[1.8](https://hub.docker.com/r/_golang/)** **(default)**
 *   custom
 
 Example

--- a/docs/services/mailhog.md
+++ b/docs/services/mailhog.md
@@ -6,8 +6,7 @@ MailHog
 Supported versions
 ------------------
 
-*   [v1.0.0](https://hub.docker.com/r/mailhog/mailhog/)
-*   [latest](https://hub.docker.com/r/mailhog/mailhog/)
+*   **[v1.0.0](https://hub.docker.com/r/mailhog/mailhog/)** **(default)**
 *   custom
 
 Example

--- a/docs/services/mariadb.md
+++ b/docs/services/mariadb.md
@@ -6,12 +6,11 @@ MariaDB
 Supported versions
 ------------------
 
-*   [10.3](https://hub.docker.com/r/_/mariadb/)
+*   [10.3](https://hub.docker.com/r/_/mariadb/)** **(default)**
 *   [10.2](https://hub.docker.com/r/_/mariadb/)
 *   [10.1](https://hub.docker.com/r/_/mariadb/)
 *   [10.0](https://hub.docker.com/r/_/mariadb/)
 *   [5.5](https://hub.docker.com/r/_/mariadb/)
-*   [latest](https://hub.docker.com/r/_/mariadb/)
 *   custom
 
 > #### Warning::Be Careful Switching Database type, version or credentials

--- a/docs/services/memcached.md
+++ b/docs/services/memcached.md
@@ -6,9 +6,8 @@ Memcached
 Supported versions
 ------------------
 
-*   [1.5](https://hub.docker.com/r/_/memcached/)
+*   **[1.5](https://hub.docker.com/r/_/memcached/)** **(default)**
 *   [1.4](https://hub.docker.com/r/_/memcached/)
-*   [latest](https://hub.docker.com/r/_/memcached/)
 *   custom
 
 Example

--- a/docs/services/mongo.md
+++ b/docs/services/mongo.md
@@ -6,11 +6,10 @@ MongoDB
 Supported versions
 ------------------
 
-*   [3.5](https://hub.docker.com/r/_/mongo/)
+*   **[3.5](https://hub.docker.com/r/_/mongo/)** **(default)**
 *   [3.4](https://hub.docker.com/r/_/mongo/)
 *   [3.2](https://hub.docker.com/r/_/mongo/)
 *   [3.0](https://hub.docker.com/r/_/mongo/)
-*   [latest](https://hub.docker.com/r/_/mongo/)
 *   custom
 
 Example

--- a/docs/services/mysql.md
+++ b/docs/services/mysql.md
@@ -7,10 +7,9 @@ Supported versions
 ------------------
 
 *   [8](https://hub.docker.com/r/_/mysql/)
-*   [5.7](https://hub.docker.com/r/_/mysql/)
+*   **[5.7](https://hub.docker.com/r/_/mysql/)** **(default)**
 *   [5.6](https://hub.docker.com/r/_/mysql/)
 *   [5.5](https://hub.docker.com/r/_/mysql/)
-*   [latest](https://hub.docker.com/r/_/mysql/)
 *   custom
 
 > #### Warning::Be Careful Switching Database type, version or credentials

--- a/docs/services/nginx.md
+++ b/docs/services/nginx.md
@@ -6,7 +6,7 @@ nginx
 Supported versions
 ------------------
 
-*   [1.13](https://hub.docker.com/r/_/nginx/)
+*   **[1.13](https://hub.docker.com/r/_/nginx/)** **(default)**
 *   [1.12](https://hub.docker.com/r/_/nginx/)
 *   [1.11](https://hub.docker.com/r/_/nginx/)
 *   [1.10](https://hub.docker.com/r/_/nginx/)
@@ -14,7 +14,6 @@ Supported versions
 *   [1.8](https://hub.docker.com/r/_/nginx/)
 *   [mainline](https://hub.docker.com/r/_/nginx/)
 *   [stable](https://hub.docker.com/r/_/nginx/)
-*   [latest](https://hub.docker.com/r/_/nginx/)
 *   custom
 
 Example

--- a/docs/services/node.md
+++ b/docs/services/node.md
@@ -6,15 +6,20 @@ node
 Supported versions
 ------------------
 
+*   [9](https://hub.docker.com/r/_/node/)
+*   [carbon](https://hub.docker.com/r/_/node/)
 *   [8](https://hub.docker.com/r/_/node/)
+*   **[8.9](https://hub.docker.com/r/_/node/)** **(default)**
 *   [8.4](https://hub.docker.com/r/_/node/)
-*   [6](https://hub.docker.com/r/_/node/)
-*   [6.11](https://hub.docker.com/r/_/node/)
+*   [8.0](https://hub.docker.com/r/_/node/)
 *   [boron](https://hub.docker.com/r/_/node/)
+*   [6](https://hub.docker.com/r/_/node/)
+*   [6.10](https://hub.docker.com/r/_/node/)
+*   [6.11](https://hub.docker.com/r/_/node/)
+*   [6.12](https://hub.docker.com/r/_/node/)
+*   [argon](https://hub.docker.com/r/_/node/)
 *   [4](https://hub.docker.com/r/_/node/)
 *   [4.8](https://hub.docker.com/r/_/node/)
-*   [argon](https://hub.docker.com/r/_/node/)
-*   [latest](https://hub.docker.com/r/_/node/)
 *   custom
 
 Example

--- a/docs/services/php.md
+++ b/docs/services/php.md
@@ -10,7 +10,7 @@ You can easily add `php` or `hhvm` to your Lando app by adding an entry to the `
 Supported Versions
 ------------------
 
-*   [7.2](https://hub.docker.com/r/devwithlando/php)
+*   **[7.2](https://hub.docker.com/r/devwithlando/php)** **(default)**
 *   [7.1](https://hub.docker.com/r/devwithlando/php)
 *   [7.0](https://hub.docker.com/r/devwithlando/php)
 *   [5.6](https://hub.docker.com/r/devwithlando/php)
@@ -18,7 +18,6 @@ Supported Versions
 *   [5.4](https://hub.docker.com/r/devwithlando/php)
 *   [5.3](https://hub.docker.com/r/devwithlando/php)
 *   [hhvm](https://hub.docker.com/r/baptistedonaux/hhvm)
-*   [latest](https://hub.docker.com/r/devwithlando/php)
 *   custom
 
 > #### Warning::Using Unsupported PHP Versions

--- a/docs/services/phpmyadmin.md
+++ b/docs/services/phpmyadmin.md
@@ -6,9 +6,8 @@ phpMyAdmin
 Supported versions
 ------------------
 
-*   [4.7](https://hub.docker.com/r/phpmyadmin/phpmyadmin/)
+*   **[4.7](https://hub.docker.com/r/phpmyadmin/phpmyadmin/)** **(default)**
 *   [4.6](https://hub.docker.com/r/phpmyadmin/phpmyadmin/)
-*   [latest](https://hub.docker.com/r/phpmyadmin/phpmyadmin/)
 *   custom
 
 Example

--- a/docs/services/postgres.md
+++ b/docs/services/postgres.md
@@ -6,7 +6,7 @@ PostgreSQL
 Supported versions
 ------------------
 
-*   [10.3](https://hub.docker.com/r/_/postgres/)
+*   **[10.3](https://hub.docker.com/r/_/postgres/)** **(default)**
 *   [10.2](https://hub.docker.com/r/_/postgres/)
 *   [10.1](https://hub.docker.com/r/_/postgres/)
 *   [10](https://hub.docker.com/r/_/postgres/)
@@ -14,7 +14,6 @@ Supported versions
 *   [9.5](https://hub.docker.com/r/_/postgres/)
 *   [9.4](https://hub.docker.com/r/_/postgres/)
 *   [9.3](https://hub.docker.com/r/_/postgres/)
-*   [latest](https://hub.docker.com/r/_/postgres/)
 *   custom
 
 > #### Warning::Be Careful Switching Database type, version or credentials

--- a/docs/services/python.md
+++ b/docs/services/python.md
@@ -7,13 +7,12 @@ Supported versions
 ------------------
 
 *   [3](https://hub.docker.com/r/_/python/)
-*   [3.6](https://hub.docker.com/r/_/python/)
+*   **[3.6](https://hub.docker.com/r/_/python/)** **(default)**
 *   [3.5](https://hub.docker.com/r/_/python/)
 *   [3.4](https://hub.docker.com/r/_/python/)
 *   [3.3](https://hub.docker.com/r/_/python/)
 *   [2](https://hub.docker.com/r/_/python/)
 *   [2.7](https://hub.docker.com/r/_/python/)
-*   [latest](https://hub.docker.com/r/_/python/)
 *   custom
 
 Example

--- a/docs/services/redis.md
+++ b/docs/services/redis.md
@@ -6,11 +6,10 @@ Redis
 Supported versions
 ------------------
 
-*   [4.0](https://hub.docker.com/r/_/redis/)
+*   **[4.0](https://hub.docker.com/r/_/redis/)** **(default)**
 *   [3.2](https://hub.docker.com/r/_/redis/)
 *   [3.0](https://hub.docker.com/r/_/redis/)
 *   [2.8](https://hub.docker.com/r/_/redis/)
-*   [latest](https://hub.docker.com/r/_/redis/)
 *   custom
 
 Example

--- a/docs/services/ruby.md
+++ b/docs/services/ruby.md
@@ -6,11 +6,10 @@ Ruby
 Supported versions
 ------------------
 
-*   [2.4](https://hub.docker.com/r/_/ruby/)
+*   **[2.4](https://hub.docker.com/r/_/ruby/)** **(default)**
 *   [2.2](https://hub.docker.com/r/_/ruby/)
 *   [2.1](https://hub.docker.com/r/_/ruby/)
 *   [1.9](https://hub.docker.com/r/_/ruby/)
-*   [latest](https://hub.docker.com/r/_/ruby/)
 *   custom
 
 Example

--- a/docs/services/solr.md
+++ b/docs/services/solr.md
@@ -6,7 +6,7 @@ Solr
 Supported versions
 ------------------
 
-*   [7.1](https://hub.docker.com/r/_/solr/)
+*   **[7.1](https://hub.docker.com/r/_/solr/)** **(default)**
 *   [7.0](https://hub.docker.com/r/_/solr/)
 *   [6.6](https://hub.docker.com/r/_/solr/)
 *   [6.5](https://hub.docker.com/r/_/solr/)
@@ -15,7 +15,6 @@ Supported versions
 *   [5.5](https://hub.docker.com/r/_/solr/)
 *   [4.10](https://hub.docker.com/r/actency/docker-solr)
 *   [3.6](https://hub.docker.com/r/actency/docker-solr)
-*   [latest](https://hub.docker.com/r/_/solr/)
 *   custom
 
 Example

--- a/docs/services/tomcat.md
+++ b/docs/services/tomcat.md
@@ -6,9 +6,8 @@ Tomcat
 Supported versions
 ------------------
 
+*   **[8](https://hub.docker.com/_/tomcat/)** **(default)**
 *   [7](https://hub.docker.com/_/tomcat/)
-*   [8](https://hub.docker.com/_/tomcat/)
-*   [latest](https://hub.docker.com/_/tomcat/)
 *   custom
 
 Example

--- a/docs/services/varnish.md
+++ b/docs/services/varnish.md
@@ -6,8 +6,7 @@ Varnish
 Supported versions
 ------------------
 
-*   [4.1](https://hub.docker.com/r/eeacms/varnish/)
-*   [latest](https://hub.docker.com/r/eeacms/varnish/)
+*   **[4.1](https://hub.docker.com/r/eeacms/varnish/)** **(default)**
 *   custom
 
 Example

--- a/plugins/lando-init/methods/github.js
+++ b/plugins/lando-init/methods/github.js
@@ -268,8 +268,8 @@ module.exports = function(lando) {
 
         // Cache the site things
         var data = {email: email};
-        var name = lando.utils.engine.dockerComposify(options.appname);
-        var siteKey = siteMetaDataKey + name;
+        var dc = lando.utils.engine.dockerComposify;
+        var siteKey = siteMetaDataKey + dc(name);
         lando.cache.set(siteKey, data, {persist: true});
 
       });

--- a/plugins/lando-services/services.js
+++ b/plugins/lando-services/services.js
@@ -19,6 +19,17 @@ module.exports = function(lando) {
   // The bridge network
   var landoBridgeNet = 'lando_bridge_network';
 
+  /**
+   * Retrieve the default version of a service.
+   * Some services don't define a default, but all SHOULD.
+   * @param {string} type The type of the service
+   * @return {string} the version to use by default, latest if isn't defined
+   * @todo Make sure all core services implement default version, then deprecate
+   */
+  var getDefaultVersion = function(type) {
+    return registry[type].defaultVersion || 'latest';
+  };
+
   /*
    * Get all services
    *
@@ -47,9 +58,8 @@ module.exports = function(lando) {
    */
   var info = function(name, type, config) {
 
-    // Parse the type and version
     var service = type.split(':')[0];
-    var version = type.split(':')[1] || 'latest';
+    var version = type.split(':')[1] || getDefaultVersion(type);
 
     // Check to verify whether the service exists in the registry
     if (!registry[service]) {
@@ -88,7 +98,7 @@ module.exports = function(lando) {
     var service = type.split(':')[0];
 
     // Add a version from the tag if available
-    config.version = type.split(':')[1] || 'latest';
+    config.version = type.split(':')[1] || getDefaultVersion(type);
 
     // Check to verify whether the service exists in the registry
     if (!registry[service]) {

--- a/plugins/lando-services/services/apache/apache.js
+++ b/plugins/lando-services/services/apache/apache.js
@@ -16,7 +16,6 @@ module.exports = function(lando) {
   var versions = [
     '2.4',
     '2.2',
-    'latest',
     'custom'
   ];
 

--- a/plugins/lando-services/services/apache/apache.js
+++ b/plugins/lando-services/services/apache/apache.js
@@ -130,6 +130,7 @@ module.exports = function(lando) {
   };
 
   return {
+    defaultVersion: '2.4',
     info: info,
     networks: networks,
     services: services,

--- a/plugins/lando-services/services/dotnet/dotnet.js
+++ b/plugins/lando-services/services/dotnet/dotnet.js
@@ -14,7 +14,6 @@ module.exports = function(lando) {
     '1',
     '1.1',
     '1.0',
-    'latest',
     'custom'
   ];
 

--- a/plugins/lando-services/services/dotnet/dotnet.js
+++ b/plugins/lando-services/services/dotnet/dotnet.js
@@ -140,6 +140,7 @@ module.exports = function(lando) {
   };
 
   return {
+    defaultVersion: '2.0',
     info: info,
     networks: networks,
     services: services,

--- a/plugins/lando-services/services/elasticsearch/elasticsearch.js
+++ b/plugins/lando-services/services/elasticsearch/elasticsearch.js
@@ -115,6 +115,7 @@ module.exports = function(lando) {
   };
 
   return {
+    defaultVersion: '5.5',
     info: info,
     networks: networks,
     services: services,

--- a/plugins/lando-services/services/elasticsearch/elasticsearch.js
+++ b/plugins/lando-services/services/elasticsearch/elasticsearch.js
@@ -15,8 +15,7 @@ module.exports = function(lando) {
     '5.4',
     '5.3',
     '5.2',
-    '5.1',
-    'latest',
+    '5.1'
   ];
 
   /*

--- a/plugins/lando-services/services/go/go.js
+++ b/plugins/lando-services/services/go/go.js
@@ -123,6 +123,7 @@ module.exports = function(lando) {
   };
 
   return {
+    defaultVersion: '1.8',
     info: info,
     networks: networks,
     services: services,

--- a/plugins/lando-services/services/go/go.js
+++ b/plugins/lando-services/services/go/go.js
@@ -11,7 +11,6 @@ module.exports = function(lando) {
   var versions = [
     '1.8.4',
     '1.8',
-    'latest',
     'custom'
   ];
 

--- a/plugins/lando-services/services/mailhog/mailhog.js
+++ b/plugins/lando-services/services/mailhog/mailhog.js
@@ -158,6 +158,7 @@ module.exports = function(lando) {
   };
 
   return {
+    defaultVersion: 'v1.0.0',
     info: info,
     networks: networks,
     services: services,

--- a/plugins/lando-services/services/mailhog/mailhog.js
+++ b/plugins/lando-services/services/mailhog/mailhog.js
@@ -15,7 +15,6 @@ module.exports = function(lando) {
    */
   var versions = [
     'v1.0.0',
-    'latest',
     'custom'
   ];
 

--- a/plugins/lando-services/services/mariadb/mariadb.js
+++ b/plugins/lando-services/services/mariadb/mariadb.js
@@ -16,7 +16,6 @@ module.exports = function(lando) {
     '10.1',
     '10.0',
     '5.5',
-    'latest',
     'custom'
   ];
 

--- a/plugins/lando-services/services/mariadb/mariadb.js
+++ b/plugins/lando-services/services/mariadb/mariadb.js
@@ -138,6 +138,7 @@ module.exports = function(lando) {
   };
 
   return {
+    defaultVersion: '10.3',
     info: info,
     networks: networks,
     services: services,

--- a/plugins/lando-services/services/memcached/memcached.js
+++ b/plugins/lando-services/services/memcached/memcached.js
@@ -8,7 +8,6 @@ module.exports = function() {
   var versions = [
     '1.5',
     '1.4',
-    'latest',
     'custom'
   ];
 

--- a/plugins/lando-services/services/memcached/memcached.js
+++ b/plugins/lando-services/services/memcached/memcached.js
@@ -92,6 +92,7 @@ module.exports = function() {
   };
 
   return {
+    defaultVersion: '1.5',
     info: info,
     networks: networks,
     services: services,

--- a/plugins/lando-services/services/mongo/mongo.js
+++ b/plugins/lando-services/services/mongo/mongo.js
@@ -15,7 +15,6 @@ module.exports = function(lando) {
     '3.4',
     '3.2',
     '3.0',
-    'latest',
     'custom'
   ];
 

--- a/plugins/lando-services/services/mongo/mongo.js
+++ b/plugins/lando-services/services/mongo/mongo.js
@@ -112,6 +112,7 @@ module.exports = function(lando) {
   };
 
   return {
+    defaultVersion: '3.5',
     info: info,
     networks: networks,
     services: services,

--- a/plugins/lando-services/services/mysql/mysql.js
+++ b/plugins/lando-services/services/mysql/mysql.js
@@ -15,7 +15,6 @@ module.exports = function(lando) {
     '5.7',
     '5.6',
     '5.5',
-    'latest',
     'custom'
   ];
 

--- a/plugins/lando-services/services/mysql/mysql.js
+++ b/plugins/lando-services/services/mysql/mysql.js
@@ -137,6 +137,7 @@ module.exports = function(lando) {
   };
 
   return {
+    defaultVersion: '5.7',
     info: info,
     networks: networks,
     services: services,

--- a/plugins/lando-services/services/nginx/nginx.js
+++ b/plugins/lando-services/services/nginx/nginx.js
@@ -22,7 +22,6 @@ module.exports = function(lando) {
     '1.8',
     'mainline',
     'stable',
-    'latest',
     'custom'
   ];
 

--- a/plugins/lando-services/services/nginx/nginx.js
+++ b/plugins/lando-services/services/nginx/nginx.js
@@ -154,6 +154,7 @@ module.exports = function(lando) {
   };
 
   return {
+    defaultVersion: '1.13',
     info: info,
     networks: networks,
     services: services,

--- a/plugins/lando-services/services/node/node.js
+++ b/plugins/lando-services/services/node/node.js
@@ -174,6 +174,7 @@ module.exports = function(lando) {
   };
 
   return {
+    defaultVersion: '8.9',
     info: info,
     networks: networks,
     services: services,

--- a/plugins/lando-services/services/node/node.js
+++ b/plugins/lando-services/services/node/node.js
@@ -23,7 +23,6 @@ module.exports = function(lando) {
     '4',
     'argon',
     '4.8',
-    'latest',
     'custom'
   ];
 

--- a/plugins/lando-services/services/php/php.js
+++ b/plugins/lando-services/services/php/php.js
@@ -23,7 +23,6 @@ module.exports = function(lando) {
     '5.4',
     '5.3',
     'hhvm',
-    'latest',
     'custom'
   ];
 

--- a/plugins/lando-services/services/php/php.js
+++ b/plugins/lando-services/services/php/php.js
@@ -417,6 +417,7 @@ module.exports = function(lando) {
   };
 
   return {
+    defaultVersion: '7.2',
     info: info,
     networks: networks,
     services: services,

--- a/plugins/lando-services/services/phpmyadmin/phpmyadmin.js
+++ b/plugins/lando-services/services/phpmyadmin/phpmyadmin.js
@@ -86,6 +86,7 @@ module.exports = function(lando) {
   };
 
   return {
+    defaultVersion: '4.7',
     info: info,
     networks: networks,
     services: services,

--- a/plugins/lando-services/services/phpmyadmin/phpmyadmin.js
+++ b/plugins/lando-services/services/phpmyadmin/phpmyadmin.js
@@ -13,7 +13,6 @@ module.exports = function(lando) {
   var versions = [
     '4.7',
     '4.6',
-    'latest',
     'custom'
   ];
 

--- a/plugins/lando-services/services/postgres/postgres.js
+++ b/plugins/lando-services/services/postgres/postgres.js
@@ -156,6 +156,7 @@ module.exports = function(lando) {
   };
 
   return {
+    defaultVersion: '10.3',
     info: info,
     networks: networks,
     services: services,

--- a/plugins/lando-services/services/postgres/postgres.js
+++ b/plugins/lando-services/services/postgres/postgres.js
@@ -18,7 +18,6 @@ module.exports = function(lando) {
     '9.5',
     '9.4',
     '9.3',
-    'latest',
     'custom'
   ];
 

--- a/plugins/lando-services/services/python/python.js
+++ b/plugins/lando-services/services/python/python.js
@@ -143,6 +143,7 @@ module.exports = function(lando) {
   };
 
   return {
+    defaultVersion: '3.6',
     info: info,
     networks: networks,
     services: services,

--- a/plugins/lando-services/services/python/python.js
+++ b/plugins/lando-services/services/python/python.js
@@ -16,7 +16,6 @@ module.exports = function(lando) {
     '3.3',
     '2',
     '2.7',
-    'latest',
     'custom'
   ];
 

--- a/plugins/lando-services/services/redis/redis.js
+++ b/plugins/lando-services/services/redis/redis.js
@@ -15,7 +15,6 @@ module.exports = function(lando) {
     '3.2',
     '3.0',
     '2.8',
-    'latest',
     'custom'
   ];
 

--- a/plugins/lando-services/services/redis/redis.js
+++ b/plugins/lando-services/services/redis/redis.js
@@ -120,6 +120,7 @@ module.exports = function(lando) {
   };
 
   return {
+    defaultVersion: '4.0',
     info: info,
     networks: networks,
     services: services,

--- a/plugins/lando-services/services/ruby/ruby.js
+++ b/plugins/lando-services/services/ruby/ruby.js
@@ -140,6 +140,7 @@ module.exports = function(lando) {
   };
 
   return {
+    defaultVersion: '2.4',
     info: info,
     networks: networks,
     services: services,

--- a/plugins/lando-services/services/ruby/ruby.js
+++ b/plugins/lando-services/services/ruby/ruby.js
@@ -13,7 +13,6 @@ module.exports = function(lando) {
     '2.2',
     '2.1',
     '1.9',
-    'latest',
     'custom'
   ];
 

--- a/plugins/lando-services/services/solr/solr.js
+++ b/plugins/lando-services/services/solr/solr.js
@@ -210,6 +210,7 @@ module.exports = function(lando) {
   };
 
   return {
+    defaultVersion: '7.1',
     info: info,
     networks: networks,
     services: services,

--- a/plugins/lando-services/services/solr/solr.js
+++ b/plugins/lando-services/services/solr/solr.js
@@ -22,7 +22,6 @@ module.exports = function(lando) {
     '6.6',
     '7.0',
     '7.1',
-    'latest',
     'custom'
   ];
 

--- a/plugins/lando-services/services/tomcat/tomcat.js
+++ b/plugins/lando-services/services/tomcat/tomcat.js
@@ -17,7 +17,6 @@ module.exports = function(lando) {
   var versions = [
     '7',
     '8',
-    'latest',
     'custom'
   ];
 

--- a/plugins/lando-services/services/tomcat/tomcat.js
+++ b/plugins/lando-services/services/tomcat/tomcat.js
@@ -146,6 +146,7 @@ module.exports = function(lando) {
   };
 
   return {
+    defaultVersion: '8',
     info: info,
     networks: networks,
     services: services,

--- a/plugins/lando-services/services/varnish/varnish.js
+++ b/plugins/lando-services/services/varnish/varnish.js
@@ -172,6 +172,7 @@ module.exports = function(lando) {
   };
 
   return {
+    defaultVersion: '4.1',
     info: info,
     networks: networks,
     services: services,

--- a/plugins/lando-services/services/varnish/varnish.js
+++ b/plugins/lando-services/services/varnish/varnish.js
@@ -16,7 +16,6 @@ module.exports = function(lando) {
    */
   var versions = [
     '4.1',
-    'latest',
     'custom'
   ];
 

--- a/scripts/build-osx.sh
+++ b/scripts/build-osx.sh
@@ -6,7 +6,7 @@ set -e
 
 # Vars
 LANDO_VERSION=$(node -pe 'JSON.parse(process.argv[1]).version' "$(cat package.json)")
-DOCKER_VERSION="18.03.0-ce-mac60"
+DOCKER_VERSION="18.03.0-ce-mac64"
 TEAM_ID="FY8GAUX282"
 PKG_SIGN=false
 DMG_SIGN=false


### PR DESCRIPTION
- [x] My code passes relevant CI status checks
- [ ] My code includes a test if applicable ([see here](https://docs.devwithlando.io/dev/testing.html))
- [x] My code includes an update to the `CHANGELOG` ([see here](https://github.com/kalabox/lando/tree/master/docs/changelog))
- [ ] My code includes documentation updates if relevant.
- [x] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

@pirog I was going to hold this for tests, however, this might be good to get out there. Working on tests right now, but the way the services plugin is structured just doesn't make it easy to do quickly
