### PR TITLE
adds auto-detection of plugins to Lando

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -2,6 +2,8 @@ name: lando.dev
 proxy:
   appserver:
     - docs.lndo.site
+autoplugin:
+  - test/autoplugin
 services:
   appserver:
     type: nginx

--- a/.lando.yml
+++ b/.lando.yml
@@ -2,8 +2,6 @@ name: lando.dev
 proxy:
   appserver:
     - docs.lndo.site
-autoplugin:
-  - test/autoplugin
 services:
   appserver:
     type: nginx

--- a/docs/dev/plugins.md
+++ b/docs/dev/plugins.md
@@ -26,9 +26,31 @@ plugins:
   - my-plugin
 ```
 
-In the above example Lando will looks for a plugin in a folder called `my-plugin` in either the `node_modules` or `plugins` folders. For app plugins these locations will be relative to the app root directory. For global plugins the locations specified in `pluginDirs` in `lando config` will be scanned.
+In the above example Lando will look for a plugin in a folder called `my-plugin` in either the `node_modules` or `plugins` folders. For app plugins these locations will be relative to the app root directory. For global plugins the locations specified in `pluginDirs` in `lando config` will be scanned.
 
-If there are multiple occurences of the same-named plugin, Lando will use the one "closest to your app". This means that `lando` will priortize in-app plugins and then priortize the locations in `pluginDirs` from last to first.
+Alternatively, you may wish to autoload plugins. This can be helpful when requiring a Lando plugin via NPM or you need to load plugins from a custom directory.
+
+```yaml
+# Lando will search the current projects root "plugins" and "node_modules" directories for plugins.
+autoplugin: true
+```
+
+In the above example, Lando scans the `plugins` and `node_modules` directory of the current project for Lando plugins.
+
+```yaml
+# Lando will search each of the paths listed for plugins within "plugins" and "node_modules" directories.
+autoplugin:
+  - some/autoload/path
+  - another/autoload/path
+```
+
+In the above example, Lando scans the `plugins` and `node_modules` directory of `[project root]/some/autoload/path` as well as `[project root]/another/autoload/path` for Lando plugins.
+
+> #### Hint::Why aren't my plugins being detected?
+>
+> In order for a plugin to be considered for auto-loading it must be within a directory named "plugins" or "node_modules" and the directory must contain an empty ".lando.config.yml"
+
+If there are multiple occurrences of the same-named plugin, Lando will use the one "closest to your app". This means that `lando` will priortize in-app plugins and then priortize the locations in `pluginDirs` from last to first.
 
 **A powerful corollary to this is that indiviual apps can implement plugins that override global plugin behavior.**
 

--- a/lib/autoplugin.js
+++ b/lib/autoplugin.js
@@ -1,0 +1,92 @@
+/**
+ * This adds loading of plugins from within project
+ *
+ * @name plugin-loader
+ */
+
+'use strict';
+
+const fs = require('fs'),
+  path = require('path');
+
+const REQUIRED_SUBDIRECTORIES = [
+  'plugins',
+  'node_modules'
+];
+
+const DEFAULT_PATH = ['./'];
+
+class Autoplugin {
+  constructor(lando) {
+    this.lando = lando;
+  }
+
+  static isLandoPlugin(pathToPlugin) {
+    const pluginConfigPath = path.join(pathToPlugin, '.lando.config.yml');
+
+    return fs.existsSync(pathToPlugin) && fs.existsSync(pluginConfigPath);
+  }
+
+  static findPlugins(source) {
+    return [].concat(...REQUIRED_SUBDIRECTORIES
+      .filter(pluginBase => fs.existsSync(path.join(source, pluginBase)))
+      .map(pluginBase => fs.readdirSync(path.join(source, pluginBase))
+        .map(name => path.join(source, pluginBase, name))
+        .filter(source => fs.lstatSync(source).isDirectory())
+      ));
+  }
+
+  static extractPluginName(relativePath) {
+    return path.basename(relativePath);
+  }
+
+  getAppConfig() {
+    return this.lando.yaml.load(this.getAppYmlPath());
+  }
+
+  getAppYmlPath() {
+    return path.join(this.lando.config.srcRoot, '.lando.yml');
+  }
+
+  listPlugins() {
+    return this.listPluginDirectories()
+      .filter(Autoplugin.isLandoPlugin)
+      .map(Autoplugin.extractPluginName);
+  }
+
+  listPluginDirectories() {
+    // Flatten array of directories after mapping
+    return [].concat(...this.getPaths()
+      .map(pluginDirectory => Autoplugin.findPlugins(path.join(process.cwd(), pluginDirectory)))
+    );
+  }
+
+  getPaths() {
+    if (this.isEnabled()) return [];
+
+    return this.isCustomPath() ? this.getAutopluginConfig() : DEFAULT_PATH;
+  }
+
+  isEnabled() {
+    return !this.getAutopluginConfig();
+  }
+
+  getAutopluginConfig() {
+    return this.getAppConfig().autoplugin;
+  }
+
+  isCustomPath() {
+    return Array.isArray(this.getAppConfig().autoplugin);
+  }
+
+  getAbsolutePaths() {
+    return this.getPaths().map(function (relativePath) {
+      return path.join(process.cwd(), relativePath);
+    });
+  }
+
+}
+
+module.exports = function (lando) {
+  return new Autoplugin(lando);
+};

--- a/lib/bootstrap.js
+++ b/lib/bootstrap.js
@@ -104,9 +104,21 @@ module.exports = _.once(function(options) {
     lando.log.debug('Config set: %j', lando.config);
   })
 
+  // Append config with project plugin directories
+  .then(function() {
+    lando.config.pluginDirs = lando.config.pluginDirs.concat(lando.autoplugin(lando).getAbsolutePaths());
+  })
+
   // Return our plugins so we can init them
   .then(function() {
     return lando.config.plugins || [];
+  })
+
+  // Append global plugins list with project plugins
+  .then(function() {
+    lando.config.plugins = lando.config.plugins.concat(lando.autoplugin(lando).listPlugins());
+
+    return lando.config.plugins;
   })
 
   // Init the plugins

--- a/lib/lando.js
+++ b/lib/lando.js
@@ -58,6 +58,7 @@ module.exports = _.memoize(function(config) {
     metrics: new Metrics(metricsConfig),
     node: require('./node'),
     plugins: require('./plugins')(log),
+    autoplugin: require('./autoplugin'),
     Promise: require('./promise'),
     scanUrls: require('./scan')(log),
     shell: require('./shell')(log),


### PR DESCRIPTION
- [x] My code passes relevant CI status checks
- [ ] My code includes a test if applicable ([see here](https://docs.devwithlando.io/dev/testing.html))
   - I started to create a test directory within `tests/autocomplete` for a proof of concept but am holding off until further guidance is provided by the Lando team
- [ ] My code includes an update to the `CHANGELOG` ([see here](https://github.com/kalabox/lando/tree/master/docs/changelog))
   - The changelog is not yet updated. I'm not quite sure how to go about documenting this according to Lando standards. This is a new feature that should be backwards compatible.
- [X] My code includes documentation updates if relevant.
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

For a detailed description of the changes and purpose of changes, please see the [updated documentation](https://github.com/tylerssn/lando/blob/master/docs/dev/plugins.md).

