### PR TITLE
Fix broken link on the php documentation page (xdebug section)

### DIFF
--- a/docs/services/php.md
+++ b/docs/services/php.md
@@ -124,7 +124,7 @@ Using Xdebug
 
 You can activate `xdebug` for remote debugging by setting `xdebug: true` in the config for your `php` service. This will enable `xdebug` and configure it so you can connect from your host machine. You will need to configure your IDE so that it can connect.
 
-Here are the instructions to [setup XDebug in Visual Studio Code](tutorials/lando-with-vscode.md).
+Here are the instructions to [setup XDebug in Visual Studio Code](https://docs.devwithlando.io/tutorials/lando-with-vscode.html).
 
 Here is some example config for [ATOM's](https://atom.io/) [`php-debug`](https://github.com/gwomacks/php-debug) plugin:
 

--- a/docs/services/php.md
+++ b/docs/services/php.md
@@ -124,7 +124,7 @@ Using Xdebug
 
 You can activate `xdebug` for remote debugging by setting `xdebug: true` in the config for your `php` service. This will enable `xdebug` and configure it so you can connect from your host machine. You will need to configure your IDE so that it can connect.
 
-Here are the instructions to [setup XDebug in Visual Studio Code](https://docs.devwithlando.io/tutorials/lando-with-vscode.html).
+Here are the instructions to [setup XDebug in Visual Studio Code](/tutorials/lando-with-vscode.html).
 
 Here is some example config for [ATOM's](https://atom.io/) [`php-debug`](https://github.com/gwomacks/php-debug) plugin:
 


### PR DESCRIPTION
<!--
- [ ] My code passes relevant CI status checks
- [ ] My code includes a test if applicable ([see here](https://docs.devwithlando.io/dev/testing.html))
- [ ] My code includes an update to the `CHANGELOG` ([see here](https://github.com/kalabox/lando/tree/master/docs/changelog))
- [X] My code includes documentation updates if relevant.
- [X] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.
-->

# Documentation Update:
While attempting to setup XDEBUG I noticed on the php page under the using-xdebug section there is a broken link to the vscode tutorial:
https://docs.devwithlando.io/services/php.html#using-xdebug

This PR changes the link to the proper URL:
https://docs.devwithlando.io/tutorials/lando-with-vscode.html