### PR TITLE
 Docs: `run_as_root`, removal of extras:

### DIFF
--- a/docs/services/php.md
+++ b/docs/services/php.md
@@ -86,7 +86,7 @@ Installed Extensions
 Installing Your Own Extensions
 ------------------------------
 
-You can install your own extensions using the [`extras`](./../config/services.md#build-extras) build step. Here is an example that installs the `memcached` extensions. Note that you will likely need to restart your app after this step for the extension to load correctly!
+You can install your own extensions using the [`run_as_root`](./../config/build.md#steps-run-as-root) build step. Here is an example that installs the `memcached` extensions. Note that you will likely need to restart your app after this step for the extension to load correctly!
 
 ```bash
 services:

--- a/docs/tutorials/setup-additional-tooling.md
+++ b/docs/tutorials/setup-additional-tooling.md
@@ -100,9 +100,9 @@ Happy testing!
 Server Installed Service: Adding `lando phantomjs` Command
 ----------------------------------------------------------
 
-We can add lando routes to server installed commands as well.  Here we will add a `lando phantomjs` command.
+We can add lando routes to server installed commands as well.  Hesre we will add a `lando phantomjs` command.
 
-Open the `.lando.yml` file for your app add an `extras` key to the `appserver` in your `.lando.yml` file and add the commands to get the `phantomjs` dependencies and the `phantomjs` binary:
+Open the `.lando.yml` file for your app add an [`run_as_root`](./../config/build.md#steps-run-as-root) key to the `appserver` in your `.lando.yml` file and add the commands to get the `phantomjs` dependencies and the `phantomjs` binary:
 
 ```yml
 services:
@@ -115,7 +115,7 @@ services:
       - "ln -s /usr/local/share/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/bin/"
 ```
 
-The `extras` section will issue these commands against the appserver. Note that `extras` will run as `root` while `build` will run as you. You can read more about that [here](https://docs.devwithlando.io/config/services.html#build-steps). After adding the `extras` key you will need to restart your app in order to have it issue these commands against the container.
+The [`run_as_root`](./../config/build.md#steps-run-as-root) section will issue these commands against the appserver. Note that [`run_as_root`](./../config/build.md#steps-run-as-root) will run as `root` while `build` will run as you. You can read more about that [here](https://docs.devwithlando.io/config/services.html#build-steps). After adding the [`run_as_root`](./../config/build.md#steps-run-as-root) key you will need to restart your app in order to have it issue these commands against the container.
 
 ```bash
 lando restart
@@ -152,7 +152,7 @@ services:
     globals:
       gulp-cli: "latest"
  ```
- 
+
 Next you can add your `update` command to the tooling, but it doesn’t actually have to do much of anything. Let’s just have it echo some text:
 
 ```yml

--- a/docs/tutorials/setup-additional-tooling.md
+++ b/docs/tutorials/setup-additional-tooling.md
@@ -100,7 +100,7 @@ Happy testing!
 Server Installed Service: Adding `lando phantomjs` Command
 ----------------------------------------------------------
 
-We can add lando routes to server installed commands as well.  Hesre we will add a `lando phantomjs` command.
+We can add lando routes to server installed commands as well.  Here we will add a `lando phantomjs` command.
 
 Open the `.lando.yml` file for your app add an [`run_as_root`](./../config/build.md#steps-run-as-root) key to the `appserver` in your `.lando.yml` file and add the commands to get the `phantomjs` dependencies and the `phantomjs` binary:
 


### PR DESCRIPTION
Thank you so much for contributing code to lando!

We will get to your PR as soon as we can but in the meantime you might want to
check to make sure you have done the following. **The more boxes you can check
the easier it will be for us to merge in your changes with confidence**

- [NA] My code passes relevant CI status checks
- [NA] My code includes a test if applicable ([see here](https://docs.devwithlando.io/dev/testing.html))
- [NA] My code includes an update to the `CHANGELOG` ([see here](https://github.com/kalabox/lando/tree/master/docs/changelog))
- [NA] My code includes documentation updates if relevant.
- [NA] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

If you are unclear about any of the above please add comments below so we can
improve our process.
-------------------------------------------------------------------------

This a documentation improvement. The current documentation shows examples with `run_as_root`, but explains everything else referring to extras.
