### PR TITLE
fix copy/paste error in commented version number

### DIFF
--- a/examples/ruby/.lando.yml
+++ b/examples/ruby/.lando.yml
@@ -12,7 +12,7 @@ services:
   # Create a ruby instance
   appserver:
 
-    # Ruby version 6.10
+    # Ruby version 2.4
     type: ruby:2.4
 
     # Optionally create certs in /certs that can be used by your application


### PR DESCRIPTION
This is a simple typo/copy/pasta fix to a comment

- [x ] My code passes relevant CI status checks
- [x ] My code includes a test if applicable ([see here](https://docs.devwithlando.io/dev/testing.html))
- [ ] My code includes an update to the `CHANGELOG` ([see here](https://github.com/kalabox/lando/tree/master/docs/changelog))
- [ ] My code includes documentation updates if relevant.
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.


