### PR TITLE
Distinguish app root from webroot in SOLR config example

### DIFF
--- a/examples/solr/.lando.yml
+++ b/examples/solr/.lando.yml
@@ -46,7 +46,7 @@ services:
 
     # Optionally use custom solr config files eg (schema.xml and solrconfig.xml)
     # This is helpful if frameworks require custom config eg Drupal.
-    # This is relative to the app root.
+    # This is relative to the app root (which may be different from your webroot).
     #config:
     #  conf: solrconf
 


### PR DESCRIPTION
(I skipped the checklist as this is just a documentation change)

It could get confusing to use app root (which is different from webroot) for SOLR. I thought app root = web root in my case because my app was running directly in the webroot. What I found after some time was that app root is where you have `.lando.yml` file.

Further, lando rebuild doesn't really report any errors when it can't find the path. Hence, I think it is a good idea to clarify this in documentation.