### PR TITLE
#1022 Add lando destroy --all

### DIFF
--- a/docs/changelog/2018.md
+++ b/docs/changelog/2018.md
@@ -6,6 +6,7 @@ If you are upgrading from pre-beta.40 follow the [beta.41 release note instructi
 **ALSO, STILL, SERIOUSLY, READ THE DOCS!: https://docs.devwithlando.io/**
 
 * Fixed various show-stopping Windows bugs [#1004](https://github.com/lando/lando/issues/1004)
+* Added ability to destroy all lando applications with `lando destroy --all` [#1022](https://github.com/lando/lando/issues/1022)
 
 v3.0.0-beta.46 - [May 27, 2018](https://github.com/lando/lando/releases/tag/v3.0.0-beta.46)
 -------------------------------

--- a/plugins/lando-app/tasks/destroy.js
+++ b/plugins/lando-app/tasks/destroy.js
@@ -20,6 +20,12 @@ module.exports = function(lando) {
           default: false,
           message: 'Are you sure you want to DESTROY?'
         }
+      },
+      all: {
+        describe: 'Destroy all applications',
+        alias: ['a'],
+        default: false,
+        boolean: true
       }
     },
     run: function(options) {
@@ -28,6 +34,32 @@ module.exports = function(lando) {
       if (!options.yes) {
         console.log(chalk.yellow('DESTRUCTION AVERTED!'));
         return;
+      }
+
+      // Destroy all the apps
+      if (options.all) {
+        // Get the list of all the apps
+        return lando.app.list()
+        .then(function(apps) {
+          // Loop through each app
+          for (var app of apps) {
+            console.log(chalk.red('Destroying ' + app.name))
+            // Retrieve the active app.
+            lando.app.get(app.name)
+            .then(function(app) {
+              // Request its destruction, if it's actually a thing.
+              if (app) {
+                return lando.app.destroy(app)
+                .then(function() {
+                  console.log(chalk.red('App destroyed!'))
+                })
+              }
+              else {
+                lando.log.warn('Could not find the app')
+              }
+            })            
+          }
+        })
       }
 
       // Try to get the app if we can

--- a/plugins/lando-app/tasks/destroy.js
+++ b/plugins/lando-app/tasks/destroy.js
@@ -43,7 +43,7 @@ module.exports = function(lando) {
         .then(function(apps) {
           // Loop through each app
           for (var app of apps) {
-            console.log(chalk.red('Destroying ' + app.name))
+            console.log(chalk.red('Destroying ' + app.name));
             // Retrieve the active app.
             lando.app.get(app.name)
             .then(function(app) {
@@ -51,15 +51,15 @@ module.exports = function(lando) {
               if (app) {
                 return lando.app.destroy(app)
                 .then(function() {
-                  console.log(chalk.red('App destroyed!'))
-                })
+                  console.log(chalk.red('App destroyed!'));
+                });
               }
               else {
-                lando.log.warn('Could not find the app')
+                lando.log.warn('Could not find the app');
               }
-            })            
+            });
           }
-        })
+        });
       }
 
       // Try to get the app if we can


### PR DESCRIPTION
This will destroy ALL lando applications. :rocket::boom::boom:

```
$ lando destroy --all -y
Destroying greenbiz
Destroying lando.dev
Removing network landodev_default
WARNING: Network landodev_default not found.
Removing volume landodev_data
WARNING: Volume landodev_data not found.
App destroyed!
Removing network greenbiz_default
Removing volume greenbiz_data
Removing volume greenbiz_appserver
Removing volume greenbiz_data_database
Removing volume greenbiz_data_index
App destroyed!
```

- [x] My code passes relevant CI status checks
- [ ] My code includes a test if applicable ([see here](https://docs.devwithlando.io/dev/testing.html))
- [x] My code includes an update to the `CHANGELOG` ([see here](https://github.com/kalabox/lando/tree/master/docs/changelog))
- [ ] My code includes documentation updates if relevant.
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

If you are unclear about any of the above please add comments below so we can
improve our process.