### PR TITLE
Add tinker command

### DIFF
--- a/docs/changelog/2018.md
+++ b/docs/changelog/2018.md
@@ -6,6 +6,7 @@ If you are upgrading from pre-beta.40 follow the [beta.41 release note instructi
 **ALSO, STILL, SERIOUSLY, READ THE DOCS!: https://docs.devwithlando.io/**
 
 * Unit tested all of core [#978](https://github.com/lando/lando/issues/978)
+* Added `tinker` command to Laravel recipe [#1125](https://github.com/lando/lando/pull/1125)
 
 v3.0.0-beta.47 - [June 1, 2018](https://github.com/lando/lando/releases/tag/v3.0.0-beta.47)
 -------------------------------

--- a/plugins/lando-recipes/recipes/laravel/laravel.js
+++ b/plugins/lando-recipes/recipes/laravel/laravel.js
@@ -81,7 +81,7 @@ module.exports = function(lando) {
       needs: needs,
       cmd: ['php', 'artisan']
     };
-    
+
     // Add tinker command
     build.tooling.tinker = {
       service: 'appserver',

--- a/plugins/lando-recipes/recipes/laravel/laravel.js
+++ b/plugins/lando-recipes/recipes/laravel/laravel.js
@@ -81,6 +81,13 @@ module.exports = function(lando) {
       needs: needs,
       cmd: ['php', 'artisan']
     };
+    
+    // Add tinker command
+    build.tooling.tinker = {
+      service: 'appserver',
+      needs: needs,
+      cmd: ['php', 'artisan', 'tinker']
+    };
 
     // Add laravel command
     build.tooling.laravel = {


### PR DESCRIPTION
One of the most common laravel commands is dropping into a tinker shell (Laravel REPL).
This PR simply adds the tool by default.

- [x] My code passes relevant CI status checks
- [ ] <strike>My code includes a test if applicable</strike>
- [x] My code includes an update to the `CHANGELOG` ([see here](https://github.com/kalabox/lando/tree/master/docs/changelog))
- [ ] <strike>My code includes documentation updates if relevant.</strike>
- [x] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.
