### PR TITLE
Update example drush command

### DIFF
--- a/docs/config/tooling.md
+++ b/docs/config/tooling.md
@@ -68,7 +68,7 @@ You can override tooling provided by Lando by redefining the tooling options in 
 tooling:
   drush:
     cmd:
-      - "drush"
+      - "drush --root=/app/web"
       - "--root=/app/web"
 ```
 

--- a/docs/config/tooling.md
+++ b/docs/config/tooling.md
@@ -67,9 +67,7 @@ You can override tooling provided by Lando by redefining the tooling options in 
 ```yml
 tooling:
   drush:
-    cmd:
-      - "drush --root=/app/web"
-      - "--root=/app/web"
+    cmd: "drush --root=/app/web"
 ```
 
 Disabling


### PR DESCRIPTION
The drush command example
```
    cmd:
      - "drush"
      - "--root=/app/web"
```

actually runs two commands: `drush` and `--root=/app/web`, which isn't a command. This changes the drush example to match other examples like "`cmd: composer --ansi`".

- [ ] My code includes an update to the [CHANGELOG](https://github.com/kalabox/lando/tree/master/docs/changelog)
- [ ] My code includes a [functional test](https://docs.devwithlando.io/dev/testing.html#functional-tests) if applicable
- [ ] My code includes a [unit test](https://docs.devwithlando.io/dev/testing.html#unit-tests) if applicable
- [x] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

If you are unclear about any of the above please add comments below so we can improve our process.
