### PR TITLE
Mount MongoDB data directory as a volume

### DIFF
--- a/examples/mongo/.lando.yml
+++ b/examples/mongo/.lando.yml
@@ -26,7 +26,8 @@ services:
 
     # Optionally use the following mongo config file
     # This is relative to the app root
-    config: config.yml
+    config:
+      conf: config.yml
 
   # Spin up services to run a basic node server
   appserver:


### PR DESCRIPTION
The MongoDB service plugin does not add a volume for the data directory for MongoDB. This means that the data does not persist once we run `lando rebuild`.

The changes in this PR also fix the issue in #1086. I have described that particular issue in a [comment on that issue](https://github.com/lando/lando/issues/1086#issuecomment-431690021). With this change, the config option is now similar to other services and should fix the problem.

- [ ] My code includes an update to the [CHANGELOG](https://github.com/kalabox/lando/tree/master/docs/changelog)
- [ ] My code includes a [functional test](https://docs.devwithlando.io/dev/testing.html#functional-tests) if applicable
- [ ] My code includes a [unit test](https://docs.devwithlando.io/dev/testing.html#unit-tests) if applicable
- [x] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

If you are unclear about any of the above please add comments below so we can improve our process.
