### PR TITLE
passing test for #1260

### DIFF
--- a/examples/pantheon/README.md
+++ b/examples/pantheon/README.md
@@ -28,7 +28,7 @@ Run the following commands to validate things are rolling as they should.
 cd web && node ../../../bin/lando.js pull --code=dev --database=dev --files=dev
 
 # Check terminus is installed
-cd web && node ../../../bin/lando.js terminus self:info | grep "terminus_version"
+cd web && node ../../../bin/lando.js terminus --version | grep 'Terminus' | grep -q '1.9.0'
 ```
 
 Cleanup


### PR DESCRIPTION
I take it from [travis run of my last PR](https://travis-ci.org/lando/lando/builds/457061446) that only unit tests are being run by CI?

This correctly returns a nonzero exit code when the expected version of `terminus` is missing from the appserver container. The double call of `grep` is due to `terminus` passing ansi escape sequences to colorize its output.

As a followup commit, the relevant changelog entry is already present in `master`