### PR TITLE
Fix reference to Drupal in WordPress example

### DIFF
--- a/examples/wordpress/.lando.yml
+++ b/examples/wordpress/.lando.yml
@@ -21,7 +21,7 @@ config:
   #
   php: '7.0'
 
-  # Optionally specify whether you want to serve drupal via nginx or apache
+  # Optionally specify whether you want to serve WordPress via nginx or apache
   #
   # If ommitted this will default to the latest apache
   #


### PR DESCRIPTION
This is just a very minor verbiage correction I noticed while browsing the docs. None of the checkboxes are really relevant here. 

- [ ] My code includes an update to the [CHANGELOG](https://github.com/kalabox/lando/tree/master/docs/changelog)
- [ ] My code includes a [functional test](https://docs.devwithlando.io/dev/testing.html#functional-tests) if applicable
- [ ] My code includes a [unit test](https://docs.devwithlando.io/dev/testing.html#unit-tests) if applicable
- [ ] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.