### PR TITLE
Correct typos in lando-info.md

### DIFF
--- a/docs/tutorials/lando-info.md
+++ b/docs/tutorials/lando-info.md
@@ -3,7 +3,7 @@ Using $LANDO_INFO
 
 Lando will inject an environment variable called `$LANDO_INFO` into each service. This is a `JSON` string representation of the `lando info` command and you can use it to see valuable information about other services such as service hostnames and database connection information and credentials.
 
-This is helpful if you want to set applicaiton configuration in a way that portable and dynamic between many lando apps.
+This is helpful if you want to set application configuration in a way that is portable and dynamic between many lando apps.
 
 > #### Warning::Use `internal_connection` information
 >


### PR DESCRIPTION
Correct spelling of "application" and add missing verb.

It's just a typo in the documentation, so there are no corresponding functional tests, unit tests, or status checks, and no CHANGELOG entry.

- [ ] My code includes an update to the [CHANGELOG](https://github.com/kalabox/lando/tree/master/docs/changelog)
- [ ] My code includes a [functional test](https://docs.devwithlando.io/dev/testing.html#functional-tests) if applicable
- [ ] My code includes a [unit test](https://docs.devwithlando.io/dev/testing.html#unit-tests) if applicable
- [x] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

If you are unclear about any of the above please add comments below so we can improve our process.
