### PR TITLE
Pantheon recipe my.cnf to match pantheon.io config for utf8mb4 support

### DIFF
--- a/plugins/lando-recipes/recipes/pantheon/mysql/my.cnf
+++ b/plugins/lando-recipes/recipes/pantheon/mysql/my.cnf
@@ -102,6 +102,9 @@ innodb_io_capacity      = 512
 innodb_flush_method     = O_DIRECT
 innodb_thread_concurrency = 8
 innodb_lock_wait_timeout = 120
+innodb_large_prefix=true
+innodb_file_format=barracuda
+
 #
 # * Security Features
 #


### PR DESCRIPTION
This PR relates to #1058 which was closed without a corresponding code change because the submitter resolved his issue locally to his own satisfaction.

Pantheon's MariaDB is configured to support multibyte utf8mb4 via the configuration `innodb_large_prefix=true`. Databases on Pantheon using utf8mb4 may fail to import during `lando pull` or `lando db-import` as a result of this configuration mismatch.

This PR alters the my.cnf file provided by the pantheon recipe to support utf8mb4 by setting `innodb_large_prefix=true` as above, as well as the related `innodb_file_format=barracuda` as required per https://mariadb.com/kb/en/library/innodb-system-variables/#innodb_large_prefix

Default character set or collation are not altered, so existing working configurations should be unaffected.

When the base image updates to MariaDB >= 10.2.2 (currently 10.0.37) these configurations will be correct by default and the options will be deprecated. Until then, this recipe update will improve compatibility with Pantheon.

Thanks!
