### PR TITLE
Add `lando stop` step to dockerfile example "burn to ground" section

### DIFF
--- a/examples/dockerfile/README.md
+++ b/examples/dockerfile/README.md
@@ -39,6 +39,9 @@ Burn it to the ground
 Run these commands to verify things have been cleaned up
 
 ```bash
+# Stop containers to remove images
+lando stop
+
 # Destroy the custom docker image
 docker rmi -f pirog/php:7.1-fpm-custom
 


### PR DESCRIPTION
If we don't stop containers first, the images don't get removed, only untagged and show as none:none.

Thank you so much for contributing code to lando!

We will get to your PR as soon as we can but in the meantime you might want to check to make sure you have done the following. **The more boxes you can check the easier it will be for us to merge in your changes with confidence**

- [ ] My code includes an update to the [CHANGELOG](https://github.com/kalabox/lando/tree/master/docs/changelog)
- [ ] My code includes a [functional test](https://docs.devwithlando.io/dev/testing.html#functional-tests) if applicable
- [ ] My code includes a [unit test](https://docs.devwithlando.io/dev/testing.html#unit-tests) if applicable
- [ ] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

If you are unclear about any of the above please add comments below so we can improve our process.
