### PR TITLE
fix links from examples back to docs

### DIFF
--- a/examples/apache/README.md
+++ b/examples/apache/README.md
@@ -3,7 +3,7 @@ Apache Example
 
 This example exists primarily to test the following documentation:
 
-* [Apache Service](https://docs.devwithlando.io/tutorial/apache.html)
+* [Apache Service](https://docs.devwithlando.io/tutorials/apache.html)
 
 Start up tests
 --------------

--- a/examples/backdrop/README.md
+++ b/examples/backdrop/README.md
@@ -3,7 +3,7 @@ Backdrop Example
 
 This example exists primarily to test the following documentation:
 
-* [Backdrop Recipe](https://docs.devwithlando.io/tutorial/backdrop.html)
+* [Backdrop Recipe](https://docs.devwithlando.io/tutorials/backdrop.html)
 
 Start up tests
 --------------

--- a/examples/compose/README.md
+++ b/examples/compose/README.md
@@ -3,7 +3,7 @@ Compose Example
 
 This example exists primarily to test the following documentation:
 
-* [Compose Service](https://docs.devwithlando.io/tutorial/compose.html)
+* [Compose Service](https://docs.devwithlando.io/tutorials/compose.html)
 
 Start up tests
 --------------

--- a/examples/dotnet/README.md
+++ b/examples/dotnet/README.md
@@ -3,7 +3,7 @@ Dotnet Example
 
 This example exists primarily to test the following documentation:
 
-* [Dotnet Service](https://docs.devwithlando.io/tutorial/dotnet.html)
+* [Dotnet Service](https://docs.devwithlando.io/tutorials/dotnet.html)
 
 Start up tests
 --------------

--- a/examples/drupal6/README.md
+++ b/examples/drupal6/README.md
@@ -3,7 +3,7 @@ Drupal 6 Example
 
 This example exists primarily to test the following documentation:
 
-* [Drupal 6 Recipe](https://docs.devwithlando.io/tutorial/drupal6.html)
+* [Drupal 6 Recipe](https://docs.devwithlando.io/tutorials/drupal6.html)
 
 Start up tests
 --------------

--- a/examples/drupal7/README.md
+++ b/examples/drupal7/README.md
@@ -3,7 +3,7 @@ Drupal 7 Example
 
 This example exists primarily to test the following documentation:
 
-* [Drupal 7 Recipe](https://docs.devwithlando.io/tutorial/drupal7.html)
+* [Drupal 7 Recipe](https://docs.devwithlando.io/tutorials/drupal7.html)
 
 Start up tests
 --------------

--- a/examples/drupal8/README.md
+++ b/examples/drupal8/README.md
@@ -3,7 +3,7 @@ Drupal 8 Example
 
 This example exists primarily to test the following documentation:
 
-* [Drupal 8 Recipe](https://docs.devwithlando.io/tutorial/drupal8.html)
+* [Drupal 8 Recipe](https://docs.devwithlando.io/tutorials/drupal8.html)
 
 Start up tests
 --------------

--- a/examples/elasticsearch/README.md
+++ b/examples/elasticsearch/README.md
@@ -3,7 +3,7 @@ Elasticsearch Example
 
 This example exists primarily to test the following documentation:
 
-* [Elasticsearch Service](https://docs.devwithlando.io/tutorial/elasticsearch.html)
+* [Elasticsearch Service](https://docs.devwithlando.io/tutorials/elasticsearch.html)
 
 Start up tests
 --------------

--- a/examples/go/README.md
+++ b/examples/go/README.md
@@ -3,7 +3,7 @@ Go Example
 
 This example exists primarily to test the following documentation:
 
-* [Go Service](https://docs.devwithlando.io/tutorial/go.html)
+* [Go Service](https://docs.devwithlando.io/tutorials/go.html)
 
 Start up tests
 --------------

--- a/examples/joomla/README.md
+++ b/examples/joomla/README.md
@@ -3,7 +3,7 @@ Joomla Example
 
 This example exists primarily to test the following documentation:
 
-* [Joomla Recipe](https://docs.devwithlando.io/tutorial/joomla.html)
+* [Joomla Recipe](https://docs.devwithlando.io/tutorials/joomla.html)
 
 Start up tests
 --------------

--- a/examples/lamp/README.md
+++ b/examples/lamp/README.md
@@ -3,7 +3,7 @@ LAMP Example
 
 This example exists primarily to test the following documentation:
 
-* [LAMP Recipe](https://docs.devwithlando.io/tutorial/lamp.html)
+* [LAMP Recipe](https://docs.devwithlando.io/tutorials/lamp.html)
 
 Start up tests
 --------------

--- a/examples/laravel/README.md
+++ b/examples/laravel/README.md
@@ -3,7 +3,7 @@ Laravel Example
 
 This example exists primarily to test the following documentation:
 
-* [Laravel Recipe](https://docs.devwithlando.io/tutorial/laravel.html)
+* [Laravel Recipe](https://docs.devwithlando.io/tutorials/laravel.html)
 
 Start up tests
 --------------

--- a/examples/lemp/README.md
+++ b/examples/lemp/README.md
@@ -3,7 +3,7 @@ LEMP Example
 
 This example exists primarily to test the following documentation:
 
-* [LEMP Recipe](https://docs.devwithlando.io/tutorial/lemp.html)
+* [LEMP Recipe](https://docs.devwithlando.io/tutorials/lemp.html)
 
 Start up tests
 --------------

--- a/examples/mailhog/README.md
+++ b/examples/mailhog/README.md
@@ -3,7 +3,7 @@ MailHog Example
 
 This example exists primarily to test the following documentation:
 
-* [MailHog Service](https://docs.devwithlando.io/tutorial/mailhog.html)
+* [MailHog Service](https://docs.devwithlando.io/tutorials/mailhog.html)
 
 Start up tests
 --------------

--- a/examples/mariadb/README.md
+++ b/examples/mariadb/README.md
@@ -3,7 +3,7 @@ MariaDB Example
 
 This example exists primarily to test the following documentation:
 
-* [MariaDB Service](https://docs.devwithlando.io/tutorial/mariadb.html)
+* [MariaDB Service](https://docs.devwithlando.io/tutorials/mariadb.html)
 
 Start up tests
 --------------

--- a/examples/mean/README.md
+++ b/examples/mean/README.md
@@ -3,7 +3,7 @@ MEAN Example
 
 This example exists primarily to test the following documentation:
 
-* [MEAN Recipe](https://docs.devwithlando.io/tutorial/mean.html)
+* [MEAN Recipe](https://docs.devwithlando.io/tutorials/mean.html)
 
 Start up tests
 --------------

--- a/examples/memcached/README.md
+++ b/examples/memcached/README.md
@@ -3,7 +3,7 @@ Memcached Example
 
 This example exists primarily to test the following documentation:
 
-* [Memcached Service](https://docs.devwithlando.io/tutorial/memcached.html)
+* [Memcached Service](https://docs.devwithlando.io/tutorials/memcached.html)
 
 Start up tests
 --------------

--- a/examples/mongo/README.md
+++ b/examples/mongo/README.md
@@ -3,7 +3,7 @@ Mongo Example
 
 This example exists primarily to test the following documentation:
 
-* [Mongo Service](https://docs.devwithlando.io/tutorial/mongo.html)
+* [Mongo Service](https://docs.devwithlando.io/tutorials/mongo.html)
 
 Start up tests
 --------------

--- a/examples/mssql/README.md
+++ b/examples/mssql/README.md
@@ -3,7 +3,7 @@ MSSQL Example
 
 This example exists primarily to test the following documentation:
 
-* [MSSQL Service](https://docs.devwithlando.io/tutorial/mssql.html)
+* [MSSQL Service](https://docs.devwithlando.io/tutorials/mssql.html)
 
 Start up tests
 --------------

--- a/examples/mysql/README.md
+++ b/examples/mysql/README.md
@@ -3,7 +3,7 @@ MySQL Example
 
 This example exists primarily to test the following documentation:
 
-* [MySQL Service](https://docs.devwithlando.io/tutorial/mysql.html)
+* [MySQL Service](https://docs.devwithlando.io/tutorials/mysql.html)
 
 Start up tests
 --------------

--- a/examples/nginx/README.md
+++ b/examples/nginx/README.md
@@ -3,7 +3,7 @@ nginx Example
 
 This example exists primarily to test the following documentation:
 
-* [nginx Service](https://docs.devwithlando.io/tutorial/nginx.html)
+* [nginx Service](https://docs.devwithlando.io/tutorials/nginx.html)
 
 Start up tests
 --------------

--- a/examples/node/README.md
+++ b/examples/node/README.md
@@ -3,7 +3,7 @@ Node Example
 
 This example exists primarily to test the following documentation:
 
-* [Node Service](https://docs.devwithlando.io/tutorial/node.html)
+* [Node Service](https://docs.devwithlando.io/tutorials/node.html)
 
 Start up tests
 --------------

--- a/examples/php/README.md
+++ b/examples/php/README.md
@@ -3,7 +3,7 @@ PHP Example
 
 This example exists primarily to test the following documentation:
 
-* [PHP Service](https://docs.devwithlando.io/tutorial/php.html)
+* [PHP Service](https://docs.devwithlando.io/tutorials/php.html)
 
 Start up tests
 --------------

--- a/examples/pma/README.md
+++ b/examples/pma/README.md
@@ -3,7 +3,7 @@ PhpMyAdmin Example
 
 This example exists primarily to test the following documentation:
 
-* [PhpMyAdmin Service](https://docs.devwithlando.io/tutorial/phpmyadmin.html)
+* [PhpMyAdmin Service](https://docs.devwithlando.io/tutorials/phpmyadmin.html)
 
 Start up tests
 --------------

--- a/examples/postgres/README.md
+++ b/examples/postgres/README.md
@@ -3,7 +3,7 @@ Postgres Example
 
 This example exists primarily to test the following documentation:
 
-* [Postgres Service](https://docs.devwithlando.io/tutorial/postgres.html)
+* [Postgres Service](https://docs.devwithlando.io/tutorials/postgres.html)
 
 Start up tests
 --------------

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -3,7 +3,7 @@ Python Example
 
 This example exists primarily to test the following documentation:
 
-* [Python Service](https://docs.devwithlando.io/tutorial/python.html)
+* [Python Service](https://docs.devwithlando.io/tutorials/python.html)
 
 Start up tests
 --------------

--- a/examples/redis/README.md
+++ b/examples/redis/README.md
@@ -3,7 +3,7 @@ Redis Example
 
 This example exists primarily to test the following documentation:
 
-* [Redis Service](https://docs.devwithlando.io/tutorial/redis.html)
+* [Redis Service](https://docs.devwithlando.io/tutorials/redis.html)
 
 Start up tests
 --------------

--- a/examples/ruby/README.md
+++ b/examples/ruby/README.md
@@ -3,7 +3,7 @@ Ruby Example
 
 This example exists primarily to test the following documentation:
 
-* [Ruby Service](https://docs.devwithlando.io/tutorial/ruby.html)
+* [Ruby Service](https://docs.devwithlando.io/tutorials/ruby.html)
 
 Start up tests
 --------------

--- a/examples/tomcat/README.md
+++ b/examples/tomcat/README.md
@@ -3,7 +3,7 @@ Tomcat Example
 
 This example exists primarily to test the following documentation:
 
-* [Tomcat Service](https://docs.devwithlando.io/tutorial/tomcat.html)
+* [Tomcat Service](https://docs.devwithlando.io/tutorials/tomcat.html)
 
 Start up tests
 --------------

--- a/examples/varnish/README.md
+++ b/examples/varnish/README.md
@@ -3,7 +3,7 @@ Varnish Example
 
 This example exists primarily to test the following documentation:
 
-* [Varnish Service](https://docs.devwithlando.io/tutorial/varnish.html)
+* [Varnish Service](https://docs.devwithlando.io/tutorials/varnish.html)
 
 Start up tests
 --------------

--- a/examples/wordpress/README.md
+++ b/examples/wordpress/README.md
@@ -3,7 +3,7 @@ WordPress Example
 
 This example exists primarily to test the following documentation:
 
-* [WordPress Recipe](https://docs.devwithlando.io/tutorial/wordpress.html)
+* [WordPress Recipe](https://docs.devwithlando.io/tutorials/wordpress.html)
 
 Start up tests
 --------------


### PR DESCRIPTION
Most or all of the `examples/*/README.md` files have broken links back to devwithlando.io. This fixes them.