### PR TITLE
Fix typo in drupal8.md

### DIFF
--- a/docs/tutorials/drupal8.md
+++ b/docs/tutorials/drupal8.md
@@ -193,7 +193,7 @@ tooling:
 
 #### Default URL Setup
 
-You may see `http://defualt` show up in many `drush` commands you run.
+You may see `http://default` show up in many `drush` commands you run.
 
 ```bash
 lando drush uli


### PR DESCRIPTION
Just a small typo in documentation.
