### PR TITLE
Update -e to -r on the sample command in rc2 upgrade guide

### DIFF
--- a/docs/guides/updating-to-rc2.md
+++ b/docs/guides/updating-to-rc2.md
@@ -559,7 +559,7 @@ A nice consequence of this is you can now use `--` in other tooling commands and
 lando terminus remote:drush "$SITE.$ENV" -- cr --all -y
 
 # Worry less about escaping crap
-lando php -e "phpinfo();"
+lando php -r "phpinfo();"
 ```
 
 Global Envvars


### PR DESCRIPTION
Running `lando php -e "phpinfo();"` results in `Could not open input file: phpinfo();`. Adjusting to `lando php -r "phpinfo();"` prints expected php info results.

Thank you so much for contributing code to Lando! If this is your **first time** contributing to Lando we recommend you check out

* [Contributing to Lando](https://docs.devwithlando.io/contrib/contributing.html)
* [Lando Developer Guide](https://docs.devwithlando.io/dev/started.html)

We will get to your PR as soon as we can but in the meantime you might want to check to make sure you have done the following. **The more boxes you can check the easier it will be for us to merge in your changes with confidence**

- [ ] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/changelog)
- [ ] My code includes a [functional test](https://docs.devwithlando.io/dev/testing.html#functional-tests) if applicable
- [ ] My code includes a [unit test](https://docs.devwithlando.io/dev/testing.html#unit-tests) if applicable
- [ ] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.
