### PR TITLE
Minor documentation fix for upgrades to RC2.

### DIFF
--- a/docs/guides/updating-to-rc2.md
+++ b/docs/guides/updating-to-rc2.md
@@ -117,7 +117,7 @@ Pain for this change will likely manifest if you have custom [proxy settings](./
 proxy:
   nginx:
     - myapp.lndo.site
-service:
+services:
   myservice:
     type: php
     via: nginx
@@ -129,7 +129,7 @@ service:
 proxy:
   myservice_nginx:
     - myapp.lndo.site
-service:
+services:
   myservice:
     type: php
     via: nginx


### PR DESCRIPTION
Example documentation incorrectly lists `service` instead of `services`.