### PR TITLE
Add support for PHP 7.3

### DIFF
--- a/docs/tutorials/php.md
+++ b/docs/tutorials/php.md
@@ -10,10 +10,9 @@ You can easily add it to your Lando app by adding an entry to the [services](./.
 Supported versions
 ------------------
 
-*   **[7.2](https://hub.docker.com/r/devwithlando/php)** **(default)**
+*   **[7.3](https://hub.docker.com/r/devwithlando/php)** **(default)**
+*   [7.2](https://hub.docker.com/r/devwithlando/php)
 *   [7.1](https://hub.docker.com/r/devwithlando/php)
-*   [7.0](https://hub.docker.com/r/devwithlando/php)
-*   [5.6](https://hub.docker.com/r/devwithlando/php)
 *   [custom](./../config/services.md#advanced)
 
 Legacy versions
@@ -25,6 +24,8 @@ Legacy versions
 
 You can still run these versions with Lando but for all intents and purposes they should be considered deprecated eg YMMV and do not expect a ton of support if you have an issue.
 
+*   [7.0](https://hub.docker.com/r/devwithlando/php)
+*   [5.6](https://hub.docker.com/r/devwithlando/php)
 *   [5.5](https://hub.docker.com/r/devwithlando/php)
 *   [5.4](https://hub.docker.com/r/devwithlando/php)
 *   [5.3](https://hub.docker.com/r/devwithlando/php)
@@ -46,7 +47,7 @@ Also note that the below options are in addition to the [build steps](./../confi
 ```yaml
 services:
   my-service:
-    type: php:7.2
+    type: php:7.3
     via: apache:2.4
     ssl: false
     webroot: .
@@ -224,65 +225,65 @@ This is useful to note if you are not using absolute paths in any [tooling route
 Installed Extensions
 --------------------
 
-|           | 5.3 | 5.4 | 5.5 | 5.6 | 7.0 | 7.1 | 7.2 |
-| --        | --- | --- | --- | --- | --- | --- | --- |
-| apc       |  X  |  X  |     |     |     |     |     |
-| apcu      |     |     |  X  |  X  |  X  |  X  |  X  |
-| bcmath    |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| bz2       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| calendar  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| Core      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| ctype     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| curl      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| date      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| dom       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| exif      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| fileinfo  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| filter    |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| ftp       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| gd        |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| gettext   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| hash      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| iconv     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| imagick   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| imap      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| intl      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| json      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| ldap      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| libxml    |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| mbstring  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| mcrypt    |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| memcached |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| mysqli    |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| mysqlnd   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| OAuth     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| OPcache   |     |     |  X  |  X  |  X  |  X  |  X  |
-| openssl   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| pcntl     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| pcre      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| PDO       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| pdo_mysql |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| pdo_pgsql |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| pdo_sqlite|  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| Phar      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| posix     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| readline  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| redis     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| readline  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| Reflection|  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| session   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| SimpleXML |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| soap      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| SPL       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| sqlite3   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| standard  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| tokenizer |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| xdebug    |     |     |     |     |     |     |     |
-| xml       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| xmlreader |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| xmlwriter |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| zip       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| zlib      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+|           | 5.3 | 5.4 | 5.5 | 5.6 | 7.0 | 7.1 | 7.2 | 7.3 |
+| --        | --- | --- | --- | --- | --- | --- | --- | --- |
+| apc       |  X  |  X  |     |     |     |     |     |     |
+| apcu      |     |     |  X  |  X  |  X  |  X  |  X  |  X  |
+| bcmath    |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| bz2       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| calendar  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| Core      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| ctype     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| curl      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| date      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| dom       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| exif      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| fileinfo  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| filter    |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| ftp       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| gd        |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| gettext   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| hash      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| iconv     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| imagick   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| imap      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| intl      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| json      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| ldap      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| libxml    |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| mbstring  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| mcrypt    |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| memcached |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| mysqli    |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| mysqlnd   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| OAuth     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| OPcache   |     |     |  X  |  X  |  X  |  X  |  X  |  X  |
+| openssl   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| pcntl     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| pcre      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| PDO       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| pdo_mysql |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| pdo_pgsql |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| pdo_sqlite|  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| Phar      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| posix     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| readline  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| redis     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| readline  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| Reflection|  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| session   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| SimpleXML |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| soap      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| SPL       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| sqlite3   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| standard  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| tokenizer |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| xdebug    |     |     |     |     |     |     |     |     |
+| xml       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| xmlreader |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| xmlwriter |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| zip       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+| zlib      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
 
 Note that `xdebug` is off by default but you can enable it on by setting your `php` services config to `xdebug: true`. Read more about this in "Configuration" above.
 

--- a/plugins/lando-services/services/php/7.3-apache/Dockerfile
+++ b/plugins/lando-services/services/php/7.3-apache/Dockerfile
@@ -1,0 +1,76 @@
+# Basic apache php 7.3 appserver for Lando
+#
+# docker build -t devwithlando/php:7.3-apache .
+
+FROM php:7.3-apache
+
+# Install dependencies we need
+RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
+  && apt-get update && apt-get install -y \
+    bzip2 \
+    exiftool \
+    git-core \
+    imagemagick \
+    libbz2-dev \
+    libc-client2007e-dev \
+    libjpeg-dev \
+    libkrb5-dev \
+    libldap2-dev \
+    libmagickwand-dev \
+    libmemcached-dev \
+    libpng-dev \
+    libpq-dev \
+    libxml2-dev \
+    libicu-dev \
+    mysql-client \
+    postgresql-client-9.6 \
+    pv \
+    ssh \
+    unzip \
+    wget \
+    xfonts-base \
+    xfonts-75dpi \
+    zlib1g-dev \
+  && pecl install apcu \
+  && pecl install imagick \
+  && pecl install memcached \
+  && pecl install oauth-2.0.3 \
+  && pecl install redis-4.2.0 \
+  && pecl install xdebug-2.7.0RC2 \
+  && docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr \
+  && docker-php-ext-configure imap --with-imap-ssl --with-kerberos \
+  && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
+  && docker-php-ext-enable apcu \
+  && docker-php-ext-enable imagick \
+  && docker-php-ext-enable memcached \
+  && docker-php-ext-enable oauth \
+  && docker-php-ext-enable redis \
+  && docker-php-ext-install \
+    bcmath \
+    bz2 \
+    calendar \
+    exif \
+    gd \
+    imap \
+    ldap \
+    mbstring \
+    mysqli \
+    opcache \
+    pdo \
+    pdo_mysql \
+    pdo_pgsql \
+    soap \
+    zip \
+    intl \
+    gettext \
+    pcntl \
+  && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+  && php -r "if (hash_file('SHA384', 'composer-setup.php') === '93b54496392c062774670ac18b134c3b3a95e5a5e5c8f1a9f115f203b75bf9a129d5daa8ba6a13e2cc8a1da0806388a8') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.8.4 \
+  && php -r "unlink('composer-setup.php');" \
+  && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
+  && su -c "composer global require hirak/prestissimo" -s /bin/sh www-data \
+  && apt-get -y clean \
+  && apt-get -y autoclean \
+  && apt-get -y autoremove \
+  && rm -rf /var/lib/apt/lists/* && rm -rf && rm -rf /var/lib/cache/* && rm -rf /var/lib/log/* && rm -rf /tmp/*

--- a/plugins/lando-services/services/php/7.3-fpm/Dockerfile
+++ b/plugins/lando-services/services/php/7.3-fpm/Dockerfile
@@ -1,0 +1,76 @@
+# Basic php-fpm 7.3 appserver for Lando
+#
+# docker build -t devwithlando/php:7.3-fpm .
+
+FROM php:7.3-fpm
+
+# Install dependencies we need
+RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
+  && apt-get update && apt-get install -y \
+    bzip2 \
+    exiftool \
+    git-core \
+    imagemagick \
+    libbz2-dev \
+    libc-client2007e-dev \
+    libjpeg-dev \
+    libkrb5-dev \
+    libldap2-dev \
+    libmagickwand-dev \
+    libmemcached-dev \
+    libpng-dev \
+    libpq-dev \
+    libxml2-dev \
+    libicu-dev \
+    mysql-client \
+    postgresql-client-9.6 \
+    pv \
+    ssh \
+    unzip \
+    wget \
+    xfonts-base \
+    xfonts-75dpi \
+    zlib1g-dev \
+  && pecl install apcu \
+  && pecl install imagick \
+  && pecl install memcached \
+  && pecl install oauth-2.0.3 \
+  && pecl install redis-4.2.0 \
+  && pecl install xdebug-2.7.0RC2 \
+  && docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr \
+  && docker-php-ext-configure imap --with-imap-ssl --with-kerberos \
+  && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
+  && docker-php-ext-enable apcu \
+  && docker-php-ext-enable imagick \
+  && docker-php-ext-enable memcached \
+  && docker-php-ext-enable oauth \
+  && docker-php-ext-enable redis \
+  && docker-php-ext-install \
+    bcmath \
+    bz2 \
+    calendar \
+    exif \
+    gd \
+    imap \
+    ldap \
+    mbstring \
+    mysqli \
+    opcache \
+    pdo \
+    pdo_mysql \
+    pdo_pgsql \
+    soap \
+    zip \
+    intl \
+    gettext \
+    pcntl \
+  && php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+  && php -r "if (hash_file('SHA384', 'composer-setup.php') === '93b54496392c062774670ac18b134c3b3a95e5a5e5c8f1a9f115f203b75bf9a129d5daa8ba6a13e2cc8a1da0806388a8') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.8.4 \
+  && php -r "unlink('composer-setup.php');" \
+  && chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
+  && su -c "composer global require hirak/prestissimo" -s /bin/sh www-data \
+  && apt-get -y clean \
+  && apt-get -y autoclean \
+  && apt-get -y autoremove \
+  && rm -rf /var/lib/apt/lists/* && rm -rf && rm -rf /var/lib/cache/* && rm -rf /var/lib/log/* && rm -rf /tmp/*

--- a/plugins/lando-services/services/php/builder.js
+++ b/plugins/lando-services/services/php/builder.js
@@ -81,9 +81,9 @@ const parseConfig = options => {
 module.exports = {
   name: 'php',
   config: {
-    version: '7.2',
-    supported: ['7.2', '7.1', '7.0', '5.6', '5.5', '5.4', '5.3'],
-    legacy: ['5.5', '5.4', '5.3'],
+    version: '7.3',
+    supported: ['7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4', '5.3'],
+    legacy: ['7.0', '5.6', '5.5', '5.4', '5.3'],
     path: [
       '/app/vendor/bin',
       '/usr/local/sbin',


### PR DESCRIPTION
Support for PHP 7.3 has been added. PHP 5.6 and 7.0 are listed as legacy because they are no longer supported.

- [x] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/changelog)
- [ ] My code includes a [functional test](https://docs.devwithlando.io/dev/testing.html#functional-tests) if applicable
- [ ] My code includes a [unit test](https://docs.devwithlando.io/dev/testing.html#unit-tests) if applicable
- [x] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.
