### PR TITLE
Compound configuration names need to match

### DIFF
--- a/docs/guides/lando-with-vscode.md
+++ b/docs/guides/lando-with-vscode.md
@@ -133,7 +133,7 @@ First, you need to have VSCode listen for debugging on 2 separate ports, because
   "compounds": [
     {
         "name": "PhpUnit",
-        "configurations": ["Normal", "PhpUnit dummy"]
+        "configurations": ["Listen for XDebug", "PhpUnit dummy"]
     }
        ]
 }


### PR DESCRIPTION
Fix an inconsistency in the example config.

"Normal" is not a valid config, replaced with right config name.
