### PR TITLE
Update drupal8.md

### DIFF
--- a/docs/tutorials/drupal8.md
+++ b/docs/tutorials/drupal8.md
@@ -72,7 +72,7 @@ Here is the [recipe config](./../config/recipes.md#config) to set the Drupal 8 r
 ```yaml
 recipe: drupal8
 config:
-  php: 7.0
+  php: '7.0'
 ```
 
 ### Choosing a webserver


### PR DESCRIPTION
php version should be in quotes when ending on a 0. It gets parsed wrong otherwise.


