### PR TITLE
Bug Report: Functional test to confirm Elasticsearch 6.5.4-6.5.14 restart without success bug

### DIFF
--- a/examples/elasticsearch65x/.lando.yml
+++ b/examples/elasticsearch65x/.lando.yml
@@ -1,0 +1,8 @@
+name: lando-elasticsearch-bug
+
+services:
+  search:
+    type: elasticsearch:5.6.14
+    overrides:
+      environment:
+        PLUGINS: analysis-phonetic,analysis-icu

--- a/examples/elasticsearch65x/README.md
+++ b/examples/elasticsearch65x/README.md
@@ -1,0 +1,43 @@
+Elasticsearch Bug Replication
+=============================
+
+This example exists primarily to verify an Elastic 6.5.x bug
+
+Start up tests
+--------------
+
+Run the following commands to get up and running
+with this example.
+
+```bash
+# Should start up successfully
+lando destroy -y
+lando start
+```
+
+Verification commands
+---------------------
+
+Run the following commands to verify the bug.
+
+```bash
+# Should poweroff
+lando poweroff
+
+# Should not start with success after first `lando start`
+lando start | grep "Service search is unhealthy"
+
+# Should have error in search log after second `lando start`
+lando logs -s search | grep "ERROR No Log4j"
+```
+
+Destroy tests
+-------------
+
+Run the following commands to trash this app like nothing ever happened.
+
+```bash
+# Should be destroyed with success
+lando destroy -y
+lando poweroff
+```


### PR DESCRIPTION
This PR is in regard to issue https://github.com/lando/lando/issues/1579. The tests confirm the existence of a bug that prevents Elasticsearch 6.5.x-6.5.14 from starting with success after `lando poweroff`.

Relevant Test: `yarn mocha --timeout 900000 test/elasticsearch-bug-replication.func.js`