### PR TITLE
#1586: ONLY ATTEMPT TO BUMP MAX_MAP_COUNT IF MAX_MAP_COUNT EXISTS

### DIFF
--- a/installer/linux/scripts/postinst
+++ b/installer/linux/scripts/postinst
@@ -19,7 +19,9 @@ ln -sf "$LANDO_ROOT/bin/lando" /usr/local/bin/lando
 SUDOERS=$(awk -F':' '$1 == "sudo" {print $4}' /etc/group)
 
 # Bump this for ES search things
-sysctl -w vm.max_map_count=262144
+if [ -f /proc/sys/vm/max_map_count ]; then
+  sysctl -w vm.max_map_count=262144
+fi
 
 # Transform sudoers into IFS default separation and loop
 for u in ${SUDOERS//,/ }


### PR DESCRIPTION
Fixes #1586 - checks whether max_map_count exists before attempting to bump it, fixing installation on platforms without max_map_count, including WSL.

- [x] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/changelog)
- [ ] My code includes a [functional test](https://docs.devwithlando.io/dev/testing.html#functional-tests) if applicable
- [ ] My code includes a [unit test](https://docs.devwithlando.io/dev/testing.html#unit-tests) if applicable
- [ ] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.
