### PR TITLE
grammar fixes

### DIFF
--- a/docs/tutorials/compose.md
+++ b/docs/tutorials/compose.md
@@ -1,7 +1,7 @@
 Compose
 =======
 
-This services is a "catch all" service that allows power users to specify custom services that are not currently one of Lando's [supported services](./../config/services.md). You can easily add it to your Lando app by adding an entry to the [services](./../config/services.md) top-level config in your [Landofile](./../config/lando.yml).
+This service is a "catch all" that allows power users to specify custom services that are not currently one of Lando's [supported services](./../config/services.md). You can easily add it to your Lando app by adding an entry to the [services](./../config/services.md) top-level config in your [Landofile](./../config/lando.yml).
 
 Technically speaking, this service is just a way for a user to define a service directly using the [Docker Compose V3](https://docs.docker.com/compose/compose-file/) file format.
 


### PR DESCRIPTION
tweaked improper plural and double "service" since the context should be clear from the first reference.
