### PR TITLE
Fixes some spelling/grammar in the Drupal 8 docs

### DIFF
--- a/docs/tutorials/drupal8.md
+++ b/docs/tutorials/drupal8.md
@@ -266,7 +266,7 @@ However, for more information we recommend you consult the [php service document
 
 You may need to override our [default Drupal 8 config](https://github.com/lando/lando/tree/master/plugins/lando-recipes/recipes/drupal8) with your own.
 
-If you do this you must use files that exists inside your applicaton and express them relative to your project root as below.
+If you do this you must use files that exist inside your application and express them relative to your project root as below.
 
 Note that the default files may change based on how you set both `ssl` and `via`. Also note that the `vhosts` and `server` config will be either for `apache` or `nginx` depending on how you set `via`. We *highly recommend* you check out both the [apache](./apache.md#configuration) and [nginx](./nginx.md#configuration) if you plan to use a custom `vhosts` or `server` config.
 
@@ -302,7 +302,7 @@ Connecting to your database
 
 Lando will automatically set up a database with a user and password and also set an environment variables called [`LANDO INFO`](./../guides/lando-info.md) that contains useful information about how your application can access other Lando services.
 
-Here are is the default database connection information for a Drupal 8 site. Note that the `host` is not `localhost` but `database`.
+Here is the default database connection information for a Drupal 8 site. Note that the `host` is not `localhost` but `database`.
 
 ```yaml
 database: drupal8


### PR DESCRIPTION
Minor documentation updates only, no code changes. 