### PR TITLE
DOCS: Fix link for "Setup XDebug in Visual Studio Code Guide"

### DIFF
--- a/docs/tutorials/php.md
+++ b/docs/tutorials/php.md
@@ -120,7 +120,7 @@ The first part of a pathmap will be the location of your code in the container. 
 
 **VSCODE**
 
-[Setup XDebug in Visual Studio Code Guide](./guides/lando-with-vscode.md)
+[Setup XDebug in Visual Studio Code Guide](./../guides/lando-with-vscode.md)
 
 #### Troubleshooting Xdebug
 


### PR DESCRIPTION
Page: https://docs.devwithlando.io/tutorials/php.html#toggling-xdebug

Issue: Under section VSCODE, link _Setup XDebug in Visual Studio Code Guide_ links to https://docs.devwithlando.io/tutorials/guides/lando-with-vscode.md but should be 
https://docs.devwithlando.io/guides/lando-with-vscode.md

- [ ] My code includes documentation updates
