### PR TITLE
Add webp support in php7.2-fpm.

### DIFF
--- a/plugins/lando-services/services/php/7.2-fpm/Dockerfile
+++ b/plugins/lando-services/services/php/7.2-fpm/Dockerfile
@@ -24,6 +24,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     libmagickwand-dev \
     libmemcached-dev \
     libpng-dev \
+    libwebp-dev \
     libpq-dev \
     libxml2-dev \
     libicu-dev \
@@ -42,7 +43,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && pecl install oauth-2.0.2 \
   && pecl install redis-3.1.2 \
   && pecl install xdebug-2.6.0beta1 \
-  && docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr \
+  && docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr --with-webp-dir=/usr \
   && docker-php-ext-configure imap --with-imap-ssl --with-kerberos \
   && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
   && docker-php-ext-enable apcu \


### PR DESCRIPTION
We will get to your PR as soon as we can but in the meantime you might want to check to make sure you have done the following. **The more boxes you can check the easier it will be for us to merge in your changes with confidence**

- [x] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/changelog)
- [ ] My code includes a [functional test](https://docs.devwithlando.io/dev/testing.html#functional-tests) if applicable
- [ ] My code includes a [unit test](https://docs.devwithlando.io/dev/testing.html#unit-tests) if applicable
- [ ] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

This is related to #1715.

This adds websupport for the `gd` extension.

Before, "WebP Support" here is false.

```
php > var_dump(gd_info());
array(13) {
  ["GD Version"]=>
  string(26) "bundled (2.1.0 compatible)"
  ["FreeType Support"]=>
  bool(true)
  ["FreeType Linkage"]=>
  string(13) "with freetype"
  ["GIF Read Support"]=>
  bool(true)
  ["GIF Create Support"]=>
  bool(true)
  ["JPEG Support"]=>
  bool(true)
  ["PNG Support"]=>
  bool(true)
  ["WBMP Support"]=>
  bool(true)
  ["XPM Support"]=>
  bool(false)
  ["XBM Support"]=>
  bool(true)
  ["WebP Support"]=>
  bool(true)
  ["BMP Support"]=>
  bool(true)
  ["JIS-mapped Japanese Font Support"]=>
  bool(false)
}
```

There are a bunch of other php images this would be added to if accepted, but I've only done the one to demonstrate the idea in case it's rejected.