### PR TITLE
Fixes #1688: Improved healthcheck for Bitnami MySQL containers.

### DIFF
--- a/plugins/lando-services/services/mysql/builder.js
+++ b/plugins/lando-services/services/mysql/builder.js
@@ -16,7 +16,7 @@ module.exports = {
       password: 'mysql',
       user: 'mysql',
     },
-    healthcheck: 'mysql -uroot --silent --execute "SHOW DATABASES;"',
+    healthcheck: 'bash -c "[ -f /bitnami/mysql/.mysql_initialized ]" && mysql -uroot --silent --execute "SHOW DATABASES;"',
     port: '3306',
     defaultFiles: {
       database: 'my_custom.cnf',


### PR DESCRIPTION
- [x] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/changelog)
- [ ] My code includes a [functional test](https://docs.devwithlando.io/dev/testing.html#functional-tests) if applicable
- [ ] My code includes a [unit test](https://docs.devwithlando.io/dev/testing.html#unit-tests) if applicable
- [ ] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

@pirog this fixes #1688 now that the Bitnami MySQL container writes the `mysql_initialized` flag file during setup. The only problem is that _existing_ Lando users running older versions of the Bitnami MySQL image won't have that, and the healthcheck will fail / time out. Do you have any idea how we can prevent that? Is there some mechanism to force people to update their container versions, or to depend on a specific version?