### PR TITLE
cert-validity-fix: Fix cert validity on iOS 13+ and macOS 10.15+

### DIFF
--- a/plugins/lando-core/scripts/add-cert.sh
+++ b/plugins/lando-core/scripts/add-cert.sh
@@ -18,6 +18,7 @@ cat > /certs/cert.ext <<EOF
 authorityKeyIdentifier=keyid,issuer
 basicConstraints=CA:FALSE
 keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+extendedKeyUsage = serverAuth
 subjectAltName = @alt_names
 [alt_names]
 DNS.1 = *.${LANDO_DOMAIN}
@@ -71,7 +72,7 @@ if [ ! -f "/certs/cert.pem" ]; then
     -CAkey $LANDO_CA_KEY \
     -CAcreateserial \
     -out /certs/cert.crt \
-    -days 8675 \
+    -days 825 \
     -sha256 \
     -extfile /certs/cert.ext
   cat /certs/cert.crt /certs/cert.key > /certs/cert.pem


### PR DESCRIPTION
Lando generated certs after 1st July 2019 are not accepted at all even after trusting the CA on iOS 13 and macOS 10.15+ (giving ERR_CERT_REVOKED in the browser) 
See: https://support.apple.com/en-us/HT210176

This PR restores the cert-generation into compatibility by:
* Adding serverAuth to the extended key usage
* Limiting validity to 825 days.
 