### PR TITLE
Allow using absolute paths for sql imports

### DIFF
--- a/plugins/lando-services/scripts/sql-import.sh
+++ b/plugins/lando-services/scripts/sql-import.sh
@@ -44,7 +44,7 @@ while (( "$#" )); do
       shift
       ;;
     *)
-      FILE="$(pwd)/$1"
+      FILE=$1
       shift
       ;;
   esac


### PR DESCRIPTION
Currently when you specify a path to an SQL file it is prefixed with `$(pwd)`, so passing `/db/mysite.sql` is translated to `/app//db/mysite-20190902-125000.sql` which is not found. The idea is to have all my databases in one directory (e.g. `/db`) and mount that volume in lando. This allows for autocompletion when I start typing `lando db-import /db/mysite-2019...` while keeping the database out of my project root. Currently instead I have to use `../` to break out of `/app/` which breaks the autocompletion.