### PR TITLE
Broken link to code contribution in docs

### DIFF
--- a/docs/contrib/contributing.md
+++ b/docs/contrib/contributing.md
@@ -76,4 +76,4 @@ If you are interested in learning more or contributing we recommend you check ou
   * [Governance](./gov.md)
   * [Roles and Responsibilities](./roles.md)
   * [Project Vision](./vision.md)
-  * [Developing](./../dev/started.md)
+  * [Developing](./started.md)


### PR DESCRIPTION
Should link to https://docs.lando.dev/contrib/started.html not https://docs.lando.dev/dev/started.html

FYI the ZenHub board link on that page doesn't seem to point anywhere