### PR TITLE
#1891: php 7.4 support

### DIFF
--- a/docs/config/php.md
+++ b/docs/config/php.md
@@ -251,7 +251,7 @@ This is useful to note if you are not using absolute paths in any [tooling route
 | hash      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
 | iconv     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
 | imagick   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
-| imap      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | -  |
+| imap      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
 | intl      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
 | json      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
 | ldap      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |

--- a/docs/config/php.md
+++ b/docs/config/php.md
@@ -12,6 +12,7 @@ You can easily add it to your Lando app by adding an entry to the [services](./.
 
 ## Supported versions
 
+*   [7.4](https://hub.docker.com/r/devwithlando/php)
 *   **[7.3](https://hub.docker.com/r/devwithlando/php)** **(default)**
 *   [7.2](https://hub.docker.com/r/devwithlando/php)
 *   [7.1](https://hub.docker.com/r/devwithlando/php)
@@ -229,65 +230,65 @@ This is useful to note if you are not using absolute paths in any [tooling route
 
 ## Installed Extensions
 
-|           | 5.3 | 5.4 | 5.5 | 5.6 | 7.0 | 7.1 | 7.2 | 7.3 |
-| --        | --- | --- | --- | --- | --- | --- | --- | --- |
-| apc       |  X  |  X  |     |     |     |     |     |     |
-| apcu      |     |     |  X  |  X  |  X  |  X  |  X  |  X  |
-| bcmath    |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| bz2       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| calendar  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| Core      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| ctype     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| curl      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| date      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| dom       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| exif      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| fileinfo  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| filter    |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| ftp       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| gd        |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| gettext   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| hash      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| iconv     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| imagick   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| imap      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| intl      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| json      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| ldap      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| libxml    |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| mbstring  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| mcrypt    |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| memcached |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| mysqli    |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| mysqlnd   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| OAuth     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| OPcache   |     |     |  X  |  X  |  X  |  X  |  X  |  X  |
-| openssl   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| pcntl     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| pcre      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| PDO       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| pdo_mysql |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| pdo_pgsql |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| pdo_sqlite|  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| Phar      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| posix     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| readline  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| redis     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| readline  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| Reflection|  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| session   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| SimpleXML |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| soap      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| SPL       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| sqlite3   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| standard  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| tokenizer |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| xdebug    |     |     |     |     |     |     |     |     |
-| xml       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| xmlreader |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| xmlwriter |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| zip       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
-| zlib      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |
+|           | 5.3 | 5.4 | 5.5 | 5.6 | 7.0 | 7.1 | 7.2 | 7.3 |7.4 |
+| --        | --- | --- | --- | --- | --- | --- | --- | --- |--- |
+| apc       |  X  |  X  |     |     |     |     |     |     |    |
+| apcu      |     |     |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| bcmath    |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| bz2       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| calendar  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| Core      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| ctype     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| curl      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| date      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| dom       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| exif      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| fileinfo  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| filter    |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| ftp       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| gd        |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| gettext   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| hash      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| iconv     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| imagick   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| imap      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | -  |
+| intl      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| json      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| ldap      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| libxml    |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| mbstring  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| mcrypt    |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| memcached |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| mysqli    |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| mysqlnd   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| OAuth     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| OPcache   |     |     |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| openssl   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| pcntl     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| pcre      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| PDO       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| pdo_mysql |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| pdo_pgsql |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| pdo_sqlite|  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| Phar      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| posix     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| readline  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| redis     |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| readline  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| Reflection|  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| session   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| SimpleXML |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| soap      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| SPL       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| sqlite3   |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| standard  |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| tokenizer |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| xdebug    |     |     |     |     |     |     |     |     |    |
+| xml       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| xmlreader |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| xmlwriter |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| zip       |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
+| zlib      |  X  |  X  |  X  |  X  |  X  |  X  |  X  |  X  | X  |
 
 Note that `xdebug` is off by default but you can enable it on by setting your `php` services config to `xdebug: true`. Read more about this in "Configuration" above.
 

--- a/docs/help/2019-changelog.md
+++ b/docs/help/2019-changelog.md
@@ -1,5 +1,9 @@
 # 2019
 
+## Unreleased
+
+* Added support for PHP 7.4 [#1891](https://github.com/lando/lando/pull/1892)
+
 ## v3.0.0-rc.24 - [December 25, 2019](https://github.com/lando/lando/releases/tag/v3.0.0-rc.24)
 
 **WHILE WE'VE TRIED TO MAINTAIN BACKWARDS COMPATIBILITY WE RECOMMEND YOU READ THE BELOW IF YOU ARE UPDATING FROM PRE RC2**

--- a/examples/php/.lando.yml
+++ b/examples/php/.lando.yml
@@ -11,6 +11,28 @@ services:
   cliold:
     type: php:5.6
     via: cli
+  cli74:
+    type: php:7.4
+    via: cli
+  custom74:
+    type: php:7.4
+    via: nginx
+    ssl: true
+    xdebug: true
+    webroot: web
+    config:
+      php: config/php.ini
+    overrides:
+      image: devwithlando/php:7.4-fpm-2
+      environment:
+        DUALBLADE: maxim
+  custom74_apache:
+    type: php:7.4
+    via: apache
+    overrides:
+      image: devwithlando/php:7.4-apache-2
+      environment:
+        DUALBLADE: maxim
   custom:
     type: php:7.1
     via: nginx

--- a/examples/php/README.md
+++ b/examples/php/README.md
@@ -48,6 +48,9 @@ lando ssh -s defaults -c "php -i | grep memory_limit | grep -e \"-1\""
 lando ssh -s defaults -c "php -m | grep xdebug" || echo $? | grep 1
 
 # Should use specified php version if given
+lando ssh -s cli74 -c "php -v" | grep "PHP 7.4"
+
+# Should use specified php version if given
 lando ssh -s custom -c "php -v" | grep "PHP 7.1"
 
 # Should serve via nginx if specified
@@ -61,6 +64,23 @@ lando ssh -s custom -c "php -m | grep xdebug"
 
 # Should not serve port 80 for cli
 lando ssh -s cli -c "curl http://localhost" || echo $? | grep 1
+
+# Should use custom php ini if specified
+lando ssh -s custom74 -c "php -i | grep memory_limit | grep 514"
+lando ssh -s custom74 -c "curl http://custom_nginx" | grep html_errors | grep On | grep On
+
+# Should inherit overrides from its generator
+lando ssh -s custom74 -c "env | grep DUALBLADE | grep maxim"
+lando ssh -s custom74_nginx -c "env | grep DUALBLADE | grep maxim"
+
+# Should enable xdebug if specified
+lando ssh -s custom74 -c "php -m | grep xdebug" || echo $? | grep 1
+
+# Should serve via nginx if specified
+lando ssh -s custom74_nginx -c "curl http://localhost | grep WEBDIR"
+
+# Should serve via apache if specified
+lando ssh -s custom74_apache -c "curl http://localhost | grep ROOTDIR"
 
 # Should use custom php ini if specified
 lando ssh -s custom -c "php -i | grep memory_limit | grep 514"

--- a/plugins/lando-services/services/php/7.4-apache/Dockerfile
+++ b/plugins/lando-services/services/php/7.4-apache/Dockerfile
@@ -55,10 +55,6 @@ RUN pecl install xdebug-2.8.1
 
 # Compile and configure all pecl packages
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr
-
-# RUN PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl
-# RUN docker-php-ext-install imap "-j${NPROC}" imap;
-
 RUN docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/
 RUN docker-php-ext-enable apcu
 RUN docker-php-ext-enable imagick
@@ -70,18 +66,18 @@ RUN docker-php-ext-install bz2
 RUN docker-php-ext-install calendar
 RUN docker-php-ext-install exif
 RUN docker-php-ext-install gd
+RUN docker-php-ext-install gettext
+RUN docker-php-ext-install intl
 RUN docker-php-ext-install ldap
 RUN docker-php-ext-install mbstring
 RUN docker-php-ext-install mysqli
 RUN docker-php-ext-install opcache
+RUN docker-php-ext-install pcntl
 RUN docker-php-ext-install pdo
 RUN docker-php-ext-install pdo_mysql
 RUN docker-php-ext-install pdo_pgsql
 RUN docker-php-ext-install soap
 RUN docker-php-ext-install zip
-RUN docker-php-ext-install intl
-RUN docker-php-ext-install gettext
-RUN docker-php-ext-install pcntl
 
 # Composer installation
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
@@ -95,3 +91,7 @@ RUN chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-da
   && apt-get -y autoclean \
   && apt-get -y autoremove \
   && rm -rf /var/lib/apt/lists/* && rm -rf && rm -rf /var/lib/cache/* && rm -rf /var/lib/log/* && rm -rf /tmp/*
+
+# Configure imap support. Purposely put at the bottom else imap configuration might fail.
+RUN PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl
+RUN docker-php-ext-install imap

--- a/plugins/lando-services/services/php/7.4-apache/Dockerfile
+++ b/plugins/lando-services/services/php/7.4-apache/Dockerfile
@@ -82,7 +82,7 @@ RUN docker-php-ext-install zip
 # Composer installation
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
   && php -r "if (hash_file('SHA384', 'composer-setup.php') === 'a5c698ffe4b8e849a443b120cd5ba38043260d5c4023dbf93e1558871f1f07f58274fc6f4c93bcfd858c6bd0775cd8d1') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.9.0 \
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.9.1 \
   && php -r "unlink('composer-setup.php');"
 
 RUN chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \

--- a/plugins/lando-services/services/php/7.4-apache/Dockerfile
+++ b/plugins/lando-services/services/php/7.4-apache/Dockerfile
@@ -1,0 +1,97 @@
+# Basic php-apache 7.4 appserver for Lando
+#
+# docker build -t devwithlando/php:7.4-apache .
+
+FROM php:7.4-apache-buster
+
+# Install dependencies we need
+RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
+  && apt -y update && apt-get install -y \
+    gnupg2 \
+    wget
+
+# Install postgresql
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main' >> /etc/apt/sources.list.d/pgdg.list \
+  && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+
+# Install default set of required packages
+RUN apt-get update && apt-get install -y \
+    bzip2 \
+    default-mysql-client \
+    exiftool \
+    git-core \
+    imagemagick \
+    libbz2-dev \
+    libc-client2007e-dev \
+    libicu-dev \
+    libjpeg-dev \
+    libkrb5-dev \
+    libldap2-dev \
+    libmagickwand-dev \
+    libmemcached-dev \
+    libpng-dev \
+    libpq-dev \
+    libssl-dev \
+    libxml2-dev \
+    libzip-dev \
+    libonig-dev \
+    openssl \
+    postgresql-client-10 \
+    pv \
+    ssh \
+    unzip \
+    wget \
+    xfonts-75dpi \
+    xfonts-base \
+    zlib1g-dev
+
+# Install PECL depedencies
+RUN pecl install apcu
+RUN pecl install imagick
+RUN pecl install memcached
+RUN pecl install oauth-2.0.4
+RUN pecl install redis-5.1.1
+RUN pecl install xdebug-2.8.1
+
+# Compile and configure all pecl packages
+RUN docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr
+
+# RUN PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl
+# RUN docker-php-ext-install imap "-j${NPROC}" imap;
+
+RUN docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/
+RUN docker-php-ext-enable apcu
+RUN docker-php-ext-enable imagick
+RUN docker-php-ext-enable memcached
+RUN docker-php-ext-enable oauth
+RUN docker-php-ext-enable redis
+RUN docker-php-ext-install bcmath
+RUN docker-php-ext-install bz2
+RUN docker-php-ext-install calendar
+RUN docker-php-ext-install exif
+RUN docker-php-ext-install gd
+RUN docker-php-ext-install ldap
+RUN docker-php-ext-install mbstring
+RUN docker-php-ext-install mysqli
+RUN docker-php-ext-install opcache
+RUN docker-php-ext-install pdo
+RUN docker-php-ext-install pdo_mysql
+RUN docker-php-ext-install pdo_pgsql
+RUN docker-php-ext-install soap
+RUN docker-php-ext-install zip
+RUN docker-php-ext-install intl
+RUN docker-php-ext-install gettext
+RUN docker-php-ext-install pcntl
+
+# Composer installation
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+  && php -r "if (hash_file('SHA384', 'composer-setup.php') === 'a5c698ffe4b8e849a443b120cd5ba38043260d5c4023dbf93e1558871f1f07f58274fc6f4c93bcfd858c6bd0775cd8d1') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.9.0 \
+  && php -r "unlink('composer-setup.php');"
+
+RUN chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
+  && su -c "composer global require hirak/prestissimo" -s /bin/sh www-data \
+  && apt-get -y clean \
+  && apt-get -y autoclean \
+  && apt-get -y autoremove \
+  && rm -rf /var/lib/apt/lists/* && rm -rf && rm -rf /var/lib/cache/* && rm -rf /var/lib/log/* && rm -rf /tmp/*

--- a/plugins/lando-services/services/php/7.4-apache/Dockerfile
+++ b/plugins/lando-services/services/php/7.4-apache/Dockerfile
@@ -54,7 +54,7 @@ RUN pecl install redis-5.1.1
 RUN pecl install xdebug-2.8.1
 
 # Compile and configure all pecl packages
-RUN docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg
 RUN docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/
 RUN docker-php-ext-enable apcu
 RUN docker-php-ext-enable imagick
@@ -81,7 +81,7 @@ RUN docker-php-ext-install zip
 
 # Composer installation
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-  && php -r "if (hash_file('SHA384', 'composer-setup.php') === 'a5c698ffe4b8e849a443b120cd5ba38043260d5c4023dbf93e1558871f1f07f58274fc6f4c93bcfd858c6bd0775cd8d1') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
+  && php -r "if (hash_file('SHA384', 'composer-setup.php') === 'baf1608c33254d00611ac1705c1d9958c817a1a33bce370c0595974b342601bd80b92a3f46067da89e3b06bff421f182') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
   && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.9.1 \
   && php -r "unlink('composer-setup.php');"
 

--- a/plugins/lando-services/services/php/7.4-apache/README.md
+++ b/plugins/lando-services/services/php/7.4-apache/README.md
@@ -60,11 +60,7 @@ RUN pecl install redis-5.1.1
 RUN pecl install xdebug-2.8.1
 
 # Compile and configure all pecl packages
-RUN docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr
-
-# RUN PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl
-# RUN docker-php-ext-install imap "-j${NPROC}" imap;
-
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg
 RUN docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/
 RUN docker-php-ext-enable apcu
 RUN docker-php-ext-enable imagick
@@ -76,22 +72,22 @@ RUN docker-php-ext-install bz2
 RUN docker-php-ext-install calendar
 RUN docker-php-ext-install exif
 RUN docker-php-ext-install gd
+RUN docker-php-ext-install gettext
+RUN docker-php-ext-install intl
 RUN docker-php-ext-install ldap
 RUN docker-php-ext-install mbstring
 RUN docker-php-ext-install mysqli
 RUN docker-php-ext-install opcache
+RUN docker-php-ext-install pcntl
 RUN docker-php-ext-install pdo
 RUN docker-php-ext-install pdo_mysql
 RUN docker-php-ext-install pdo_pgsql
 RUN docker-php-ext-install soap
 RUN docker-php-ext-install zip
-RUN docker-php-ext-install intl
-RUN docker-php-ext-install gettext
-RUN docker-php-ext-install pcntl
 
 # Composer installation
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-  && php -r "if (hash_file('SHA384', 'composer-setup.php') === 'a5c698ffe4b8e849a443b120cd5ba38043260d5c4023dbf93e1558871f1f07f58274fc6f4c93bcfd858c6bd0775cd8d1') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
+  && php -r "if (hash_file('SHA384', 'composer-setup.php') === 'baf1608c33254d00611ac1705c1d9958c817a1a33bce370c0595974b342601bd80b92a3f46067da89e3b06bff421f182') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
   && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.9.1 \
   && php -r "unlink('composer-setup.php');"
 
@@ -101,4 +97,8 @@ RUN chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-da
   && apt-get -y autoclean \
   && apt-get -y autoremove \
   && rm -rf /var/lib/apt/lists/* && rm -rf && rm -rf /var/lib/cache/* && rm -rf /var/lib/log/* && rm -rf /tmp/*
+
+# Configure imap support. Purposely put at the bottom else imap configuration might fail.
+RUN PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl
+RUN docker-php-ext-install imap
 ```

--- a/plugins/lando-services/services/php/7.4-apache/README.md
+++ b/plugins/lando-services/services/php/7.4-apache/README.md
@@ -1,0 +1,104 @@
+Lando Apache PHP 7.4 appserver
+==============================
+
+A decent cross purpose apache based php 7.4 appserver.
+
+```
+# Basic php-apache 7.4 appserver for Lando
+#
+# docker build -t devwithlando/php:7.4-apache .
+
+FROM php:7.4-apache-buster
+
+# Install dependencies we need
+RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
+  && apt -y update && apt-get install -y \
+    gnupg2 \
+    wget
+
+# Install postgresql
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main' >> /etc/apt/sources.list.d/pgdg.list \
+  && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+
+# Install default set of required packages
+RUN apt-get update && apt-get install -y \
+    bzip2 \
+    default-mysql-client \
+    exiftool \
+    git-core \
+    imagemagick \
+    libbz2-dev \
+    libc-client2007e-dev \
+    libicu-dev \
+    libjpeg-dev \
+    libkrb5-dev \
+    libldap2-dev \
+    libmagickwand-dev \
+    libmemcached-dev \
+    libpng-dev \
+    libpq-dev \
+    libssl-dev \
+    libxml2-dev \
+    libzip-dev \
+    libonig-dev \
+    openssl \
+    postgresql-client-10 \
+    pv \
+    ssh \
+    unzip \
+    wget \
+    xfonts-75dpi \
+    xfonts-base \
+    zlib1g-dev
+
+# Install PECL depedencies
+RUN pecl install apcu
+RUN pecl install imagick
+RUN pecl install memcached
+RUN pecl install oauth-2.0.4
+RUN pecl install redis-5.1.1
+RUN pecl install xdebug-2.8.1
+
+# Compile and configure all pecl packages
+RUN docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr
+
+# RUN PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl
+# RUN docker-php-ext-install imap "-j${NPROC}" imap;
+
+RUN docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/
+RUN docker-php-ext-enable apcu
+RUN docker-php-ext-enable imagick
+RUN docker-php-ext-enable memcached
+RUN docker-php-ext-enable oauth
+RUN docker-php-ext-enable redis
+RUN docker-php-ext-install bcmath
+RUN docker-php-ext-install bz2
+RUN docker-php-ext-install calendar
+RUN docker-php-ext-install exif
+RUN docker-php-ext-install gd
+RUN docker-php-ext-install ldap
+RUN docker-php-ext-install mbstring
+RUN docker-php-ext-install mysqli
+RUN docker-php-ext-install opcache
+RUN docker-php-ext-install pdo
+RUN docker-php-ext-install pdo_mysql
+RUN docker-php-ext-install pdo_pgsql
+RUN docker-php-ext-install soap
+RUN docker-php-ext-install zip
+RUN docker-php-ext-install intl
+RUN docker-php-ext-install gettext
+RUN docker-php-ext-install pcntl
+
+# Composer installation
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+  && php -r "if (hash_file('SHA384', 'composer-setup.php') === 'a5c698ffe4b8e849a443b120cd5ba38043260d5c4023dbf93e1558871f1f07f58274fc6f4c93bcfd858c6bd0775cd8d1') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.9.0 \
+  && php -r "unlink('composer-setup.php');"
+
+RUN chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
+  && su -c "composer global require hirak/prestissimo" -s /bin/sh www-data \
+  && apt-get -y clean \
+  && apt-get -y autoclean \
+  && apt-get -y autoremove \
+  && rm -rf /var/lib/apt/lists/* && rm -rf && rm -rf /var/lib/cache/* && rm -rf /var/lib/log/* && rm -rf /tmp/*
+```

--- a/plugins/lando-services/services/php/7.4-apache/README.md
+++ b/plugins/lando-services/services/php/7.4-apache/README.md
@@ -92,7 +92,7 @@ RUN docker-php-ext-install pcntl
 # Composer installation
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
   && php -r "if (hash_file('SHA384', 'composer-setup.php') === 'a5c698ffe4b8e849a443b120cd5ba38043260d5c4023dbf93e1558871f1f07f58274fc6f4c93bcfd858c6bd0775cd8d1') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.9.0 \
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.9.1 \
   && php -r "unlink('composer-setup.php');"
 
 RUN chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \

--- a/plugins/lando-services/services/php/7.4-fpm/Dockerfile
+++ b/plugins/lando-services/services/php/7.4-fpm/Dockerfile
@@ -83,7 +83,7 @@ RUN docker-php-ext-install zip
 # Composer installation
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
   && php -r "if (hash_file('SHA384', 'composer-setup.php') === 'a5c698ffe4b8e849a443b120cd5ba38043260d5c4023dbf93e1558871f1f07f58274fc6f4c93bcfd858c6bd0775cd8d1') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.9.0 \
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.9.1 \
   && php -r "unlink('composer-setup.php');"
 
 RUN chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \

--- a/plugins/lando-services/services/php/7.4-fpm/Dockerfile
+++ b/plugins/lando-services/services/php/7.4-fpm/Dockerfile
@@ -54,7 +54,7 @@ RUN pecl install redis-5.1.1
 RUN pecl install xdebug-2.8.1
 
 # Compile and configure all pecl packages
-RUN docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg
 RUN docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/
 RUN docker-php-ext-enable apcu
 RUN docker-php-ext-enable imagick
@@ -82,7 +82,7 @@ RUN docker-php-ext-install zip
 
 # Composer installation
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-  && php -r "if (hash_file('SHA384', 'composer-setup.php') === 'a5c698ffe4b8e849a443b120cd5ba38043260d5c4023dbf93e1558871f1f07f58274fc6f4c93bcfd858c6bd0775cd8d1') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
+  && php -r "if (hash_file('SHA384', 'composer-setup.php') === 'baf1608c33254d00611ac1705c1d9958c817a1a33bce370c0595974b342601bd80b92a3f46067da89e3b06bff421f182') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
   && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.9.1 \
   && php -r "unlink('composer-setup.php');"
 

--- a/plugins/lando-services/services/php/7.4-fpm/Dockerfile
+++ b/plugins/lando-services/services/php/7.4-fpm/Dockerfile
@@ -1,0 +1,97 @@
+# Basic php-fpm 7.3 appserver for Lando
+#
+# docker build -t devwithlando/php:7.3-fpm .
+
+FROM php:7.4-fpm-buster
+
+# Install dependencies we need
+RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
+  && apt -y update && apt-get install -y \
+    gnupg2 \
+    wget
+
+# Install postgresql
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main' >> /etc/apt/sources.list.d/pgdg.list \
+  && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+
+# Install default set of required packages
+RUN apt-get update && apt-get install -y \
+    bzip2 \
+    default-mysql-client \
+    exiftool \
+    git-core \
+    imagemagick \
+    libbz2-dev \
+    libc-client2007e-dev \
+    libicu-dev \
+    libjpeg-dev \
+    libkrb5-dev \
+    libldap2-dev \
+    libmagickwand-dev \
+    libmemcached-dev \
+    libpng-dev \
+    libpq-dev \
+    libssl-dev \
+    libxml2-dev \
+    libzip-dev \
+    libonig-dev \
+    openssl \
+    postgresql-client-10 \
+    pv \
+    ssh \
+    unzip \
+    wget \
+    xfonts-75dpi \
+    xfonts-base \
+    zlib1g-dev
+
+# Install PECL depedencies
+RUN pecl install apcu
+RUN pecl install imagick
+RUN pecl install memcached
+RUN pecl install oauth-2.0.4
+RUN pecl install redis-5.1.1
+RUN pecl install xdebug-2.8.1
+
+# Compile and configure all pecl packages
+RUN docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr
+
+# RUN PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl
+# RUN docker-php-ext-install imap "-j${NPROC}" imap;
+
+RUN docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/
+RUN docker-php-ext-enable apcu
+RUN docker-php-ext-enable imagick
+RUN docker-php-ext-enable memcached
+RUN docker-php-ext-enable oauth
+RUN docker-php-ext-enable redis
+RUN docker-php-ext-install bcmath
+RUN docker-php-ext-install bz2
+RUN docker-php-ext-install calendar
+RUN docker-php-ext-install exif
+RUN docker-php-ext-install gd
+RUN docker-php-ext-install ldap
+RUN docker-php-ext-install mbstring
+RUN docker-php-ext-install mysqli
+RUN docker-php-ext-install opcache
+RUN docker-php-ext-install pdo
+RUN docker-php-ext-install pdo_mysql
+RUN docker-php-ext-install pdo_pgsql
+RUN docker-php-ext-install soap
+RUN docker-php-ext-install zip
+RUN docker-php-ext-install intl
+RUN docker-php-ext-install gettext
+RUN docker-php-ext-install pcntl
+
+# Composer installation
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+  && php -r "if (hash_file('SHA384', 'composer-setup.php') === 'a5c698ffe4b8e849a443b120cd5ba38043260d5c4023dbf93e1558871f1f07f58274fc6f4c93bcfd858c6bd0775cd8d1') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.9.0 \
+  && php -r "unlink('composer-setup.php');"
+
+RUN chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
+  && su -c "composer global require hirak/prestissimo" -s /bin/sh www-data \
+  && apt-get -y clean \
+  && apt-get -y autoclean \
+  && apt-get -y autoremove \
+  && rm -rf /var/lib/apt/lists/* && rm -rf && rm -rf /var/lib/cache/* && rm -rf /var/lib/log/* && rm -rf /tmp/*

--- a/plugins/lando-services/services/php/7.4-fpm/Dockerfile
+++ b/plugins/lando-services/services/php/7.4-fpm/Dockerfile
@@ -55,10 +55,6 @@ RUN pecl install xdebug-2.8.1
 
 # Compile and configure all pecl packages
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr
-
-# RUN PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl
-# RUN docker-php-ext-install imap "-j${NPROC}" imap;
-
 RUN docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/
 RUN docker-php-ext-enable apcu
 RUN docker-php-ext-enable imagick
@@ -70,18 +66,19 @@ RUN docker-php-ext-install bz2
 RUN docker-php-ext-install calendar
 RUN docker-php-ext-install exif
 RUN docker-php-ext-install gd
+RUN docker-php-ext-install gettext
+RUN docker-php-ext-install intl
 RUN docker-php-ext-install ldap
 RUN docker-php-ext-install mbstring
 RUN docker-php-ext-install mysqli
 RUN docker-php-ext-install opcache
+RUN docker-php-ext-install pcntl
 RUN docker-php-ext-install pdo
 RUN docker-php-ext-install pdo_mysql
 RUN docker-php-ext-install pdo_pgsql
 RUN docker-php-ext-install soap
 RUN docker-php-ext-install zip
-RUN docker-php-ext-install intl
-RUN docker-php-ext-install gettext
-RUN docker-php-ext-install pcntl
+
 
 # Composer installation
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
@@ -95,3 +92,7 @@ RUN chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-da
   && apt-get -y autoclean \
   && apt-get -y autoremove \
   && rm -rf /var/lib/apt/lists/* && rm -rf && rm -rf /var/lib/cache/* && rm -rf /var/lib/log/* && rm -rf /tmp/*
+
+# Configure imap support. Purposely put at the bottom else imap configuration might fail.
+RUN PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl
+RUN docker-php-ext-install imap

--- a/plugins/lando-services/services/php/7.4-fpm/Dockerfile
+++ b/plugins/lando-services/services/php/7.4-fpm/Dockerfile
@@ -1,6 +1,6 @@
-# Basic php-fpm 7.3 appserver for Lando
+# Basic php-fpm 7.4 appserver for Lando
 #
-# docker build -t devwithlando/php:7.3-fpm .
+# docker build -t devwithlando/php:7.4-fpm .
 
 FROM php:7.4-fpm-buster
 

--- a/plugins/lando-services/services/php/7.4-fpm/README.md
+++ b/plugins/lando-services/services/php/7.4-fpm/README.md
@@ -1,0 +1,101 @@
+Lando PHP-FPM 7.4 appserver
+===========================
+
+A decent cross purpose fpm based php 7.4 appserver.
+
+```
+# Basic php-fpm 7.3 appserver for Lando
+#
+# docker build -t devwithlando/php:7.3-fpm .
+
+FROM php:7.4-fpm-buster
+
+# Install dependencies we need
+RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
+  && apt -y update && apt-get install -y \
+    gnupg2 \
+    wget
+
+# Install postgresql
+RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main' >> /etc/apt/sources.list.d/pgdg.list \
+  && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
+
+# Install default set of required packages
+RUN apt-get update && apt-get install -y \
+    bzip2 \
+    default-mysql-client \
+    exiftool \
+    git-core \
+    imagemagick \
+    libbz2-dev \
+    libc-client2007e-dev \
+    libicu-dev \
+    libjpeg-dev \
+    libkrb5-dev \
+    libldap2-dev \
+    libmagickwand-dev \
+    libmemcached-dev \
+    libpng-dev \
+    libpq-dev \
+    libssl-dev \
+    libxml2-dev \
+    libzip-dev \
+    openssl \
+    postgresql-client-10 \
+    pv \
+    ssh \
+    unzip \
+    wget \
+    xfonts-75dpi \
+    xfonts-base \
+    zlib1g-dev
+
+# Install PECL depedencies
+RUN pecl install apcu
+RUN pecl install imagick
+RUN pecl install memcached
+RUN pecl install oauth-2.0.4
+RUN pecl install redis-5.1.1
+RUN pecl install xdebug-2.8.1
+
+# Compile and configure all pecl packages
+RUN docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr
+RUN PHP_OPENSSL=yes docker-php-ext-configure imap --with-imap-ssl --with-kerberos
+RUN docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/
+RUN docker-php-ext-enable apcu
+RUN docker-php-ext-enable imagick
+RUN docker-php-ext-enable memcached
+RUN docker-php-ext-enable oauth
+RUN docker-php-ext-enable redis
+RUN docker-php-ext-install bcmath
+RUN docker-php-ext-install bz2
+RUN docker-php-ext-install calendar
+RUN docker-php-ext-install exif
+RUN docker-php-ext-install gd
+RUN docker-php-ext-install imap
+RUN docker-php-ext-install ldap
+RUN docker-php-ext-install mbstring
+RUN docker-php-ext-install mysqli
+RUN docker-php-ext-install opcache
+RUN docker-php-ext-install pdo
+RUN docker-php-ext-install pdo_mysql
+RUN docker-php-ext-install pdo_pgsql
+RUN docker-php-ext-install soap
+RUN docker-php-ext-install zip
+RUN docker-php-ext-install intl
+RUN docker-php-ext-install gettext
+RUN docker-php-ext-install pcn
+
+# Composer installation
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+  && php -r "if (hash_file('SHA384', 'composer-setup.php') === 'a5c698ffe4b8e849a443b120cd5ba38043260d5c4023dbf93e1558871f1f07f58274fc6f4c93bcfd858c6bd0775cd8d1') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.9.0 \
+  && php -r "unlink('composer-setup.php');"
+
+RUN chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \
+  && su -c "composer global require hirak/prestissimo" -s /bin/sh www-data \
+  && apt-get -y clean \
+  && apt-get -y autoclean \
+  && apt-get -y autoremove \
+  && rm -rf /var/lib/apt/lists/* && rm -rf && rm -rf /var/lib/cache/* && rm -rf /var/lib/log/* && rm -rf /tmp/*
+```

--- a/plugins/lando-services/services/php/7.4-fpm/README.md
+++ b/plugins/lando-services/services/php/7.4-fpm/README.md
@@ -92,7 +92,7 @@ RUN docker-php-ext-install pcntl
 # Composer installation
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
   && php -r "if (hash_file('SHA384', 'composer-setup.php') === 'a5c698ffe4b8e849a443b120cd5ba38043260d5c4023dbf93e1558871f1f07f58274fc6f4c93bcfd858c6bd0775cd8d1') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.9.0 \
+  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.9.1 \
   && php -r "unlink('composer-setup.php');"
 
 RUN chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-data:www-data /var/www \

--- a/plugins/lando-services/services/php/7.4-fpm/README.md
+++ b/plugins/lando-services/services/php/7.4-fpm/README.md
@@ -60,11 +60,7 @@ RUN pecl install redis-5.1.1
 RUN pecl install xdebug-2.8.1
 
 # Compile and configure all pecl packages
-RUN docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr
-
-# RUN PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl
-# RUN docker-php-ext-install imap "-j${NPROC}" imap;
-
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg
 RUN docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/
 RUN docker-php-ext-enable apcu
 RUN docker-php-ext-enable imagick
@@ -76,22 +72,23 @@ RUN docker-php-ext-install bz2
 RUN docker-php-ext-install calendar
 RUN docker-php-ext-install exif
 RUN docker-php-ext-install gd
+RUN docker-php-ext-install gettext
+RUN docker-php-ext-install intl
 RUN docker-php-ext-install ldap
 RUN docker-php-ext-install mbstring
 RUN docker-php-ext-install mysqli
 RUN docker-php-ext-install opcache
+RUN docker-php-ext-install pcntl
 RUN docker-php-ext-install pdo
 RUN docker-php-ext-install pdo_mysql
 RUN docker-php-ext-install pdo_pgsql
 RUN docker-php-ext-install soap
 RUN docker-php-ext-install zip
-RUN docker-php-ext-install intl
-RUN docker-php-ext-install gettext
-RUN docker-php-ext-install pcntl
+
 
 # Composer installation
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-  && php -r "if (hash_file('SHA384', 'composer-setup.php') === 'a5c698ffe4b8e849a443b120cd5ba38043260d5c4023dbf93e1558871f1f07f58274fc6f4c93bcfd858c6bd0775cd8d1') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
+  && php -r "if (hash_file('SHA384', 'composer-setup.php') === 'baf1608c33254d00611ac1705c1d9958c817a1a33bce370c0595974b342601bd80b92a3f46067da89e3b06bff421f182') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" \
   && php composer-setup.php --install-dir=/usr/local/bin --filename=composer --version=1.9.1 \
   && php -r "unlink('composer-setup.php');"
 
@@ -101,4 +98,8 @@ RUN chsh -s /bin/bash www-data && mkdir -p /var/www/.composer && chown -R www-da
   && apt-get -y autoclean \
   && apt-get -y autoremove \
   && rm -rf /var/lib/apt/lists/* && rm -rf && rm -rf /var/lib/cache/* && rm -rf /var/lib/log/* && rm -rf /tmp/*
+
+# Configure imap support. Purposely put at the bottom else imap configuration might fail.
+RUN PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl
+RUN docker-php-ext-install imap
 ```

--- a/plugins/lando-services/services/php/7.4-fpm/README.md
+++ b/plugins/lando-services/services/php/7.4-fpm/README.md
@@ -4,9 +4,9 @@ Lando PHP-FPM 7.4 appserver
 A decent cross purpose fpm based php 7.4 appserver.
 
 ```
-# Basic php-fpm 7.3 appserver for Lando
+# Basic php-fpm 7.4 appserver for Lando
 #
-# docker build -t devwithlando/php:7.3-fpm .
+# docker build -t devwithlando/php:7.4-fpm .
 
 FROM php:7.4-fpm-buster
 
@@ -40,6 +40,7 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     libxml2-dev \
     libzip-dev \
+    libonig-dev \
     openssl \
     postgresql-client-10 \
     pv \
@@ -60,7 +61,10 @@ RUN pecl install xdebug-2.8.1
 
 # Compile and configure all pecl packages
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr --with-png-dir=/usr --with-jpeg-dir=/usr
-RUN PHP_OPENSSL=yes docker-php-ext-configure imap --with-imap-ssl --with-kerberos
+
+# RUN PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl
+# RUN docker-php-ext-install imap "-j${NPROC}" imap;
+
 RUN docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/
 RUN docker-php-ext-enable apcu
 RUN docker-php-ext-enable imagick
@@ -72,7 +76,6 @@ RUN docker-php-ext-install bz2
 RUN docker-php-ext-install calendar
 RUN docker-php-ext-install exif
 RUN docker-php-ext-install gd
-RUN docker-php-ext-install imap
 RUN docker-php-ext-install ldap
 RUN docker-php-ext-install mbstring
 RUN docker-php-ext-install mysqli
@@ -84,7 +87,7 @@ RUN docker-php-ext-install soap
 RUN docker-php-ext-install zip
 RUN docker-php-ext-install intl
 RUN docker-php-ext-install gettext
-RUN docker-php-ext-install pcn
+RUN docker-php-ext-install pcntl
 
 # Composer installation
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \

--- a/plugins/lando-services/services/php/builder.js
+++ b/plugins/lando-services/services/php/builder.js
@@ -83,7 +83,7 @@ module.exports = {
   name: 'php',
   config: {
     version: '7.3',
-    supported: ['7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4', '5.3'],
+    supported: ['7.4', '7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4', '5.3'],
     legacy: ['5.5', '5.4', '5.3'],
     path: [
       '/app/vendor/bin',


### PR DESCRIPTION
This adds PHP 7.4 support to Lando. It follows similar setup as the previous versions and includes the same extensions as 7.3

- [X] My code includes the latest code from the `master` branch
- [x] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/help)
- [X] My code includes documentation updates if applicable.
- [X] My code passes relevant CI status checks
- [x] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.
 