### PR TITLE
1714 stop all except current

### DIFF
--- a/docs/basics/poweroff.md
+++ b/docs/basics/poweroff.md
@@ -7,17 +7,27 @@ description: No! Shut them all down! lando poweroff will stop ALL lando related 
 
 Spins down all lando related containers
 
-This is useful if you want to deactive all the containers needed to run Lando. If you have another service that requires usual system resources like ports `80` and `443` this command will free them up.
+This is useful if you want to deactivate all the containers needed to run Lando. If you have another service that requires usual system resources like ports `80` and `443` this command will free them up.
+
+Containers from one or more apps can be kept running with `--exclude`. Note that all global containers (such as the Lando proxy) will be skipped if `--exclude` is used, regardless of whether a matching app is found.
 
 ## Usage
 
 ```bash
+# Spin down all running Lando containers
 lando poweroff
+
+# Spin down all containers, except those associated with a specific app
+lando poweroff --exclude myapp1
+
+# Multiple apps can be excluded with a single command
+lando poweroff --exclude myapp1 --exclude myapp2
 ```
 
 ## Options
 
 ```bash
+--exclude, -e  Exclude containers from one or more apps from being shut down
 --clear        Clears the lando tasks cache
 --help         Shows lando or delegated command help if applicable
 --verbose, -v  Runs with extra verbosity

--- a/docs/basics/start.md
+++ b/docs/basics/start.md
@@ -16,12 +16,17 @@ If you start an app with a new service or container it will need to pull that co
 ## Usage
 
 ```bash
+# Start your app
 lando start
+
+# Shut down any other running apps before starting this one
+lando start --only
 ```
 
 ## Options
 
 ```bash
+--only, -o     Shut down any other running apps before starting this one
 --clear        Clears the lando tasks cache
 --help         Shows lando or delegated command help if applicable
 --verbose, -v  Runs with extra verbosity

--- a/examples/base/README.md
+++ b/examples/base/README.md
@@ -137,6 +137,12 @@ docker ps --filter label=io.lando.container=TRUE -q | wc -l | grep 3
 lando poweroff
 docker ps --filter label=io.lando.container=TRUE -q | wc -l | grep 0
 
+# Should skip stopping lando base app
+lando start
+docker ps --filter label=io.lando.container=TRUE -q | wc -l | grep 3
+lando poweroff --exclude landobase
+docker ps --filter label=io.lando.container=TRUE -q | wc -l | grep 3
+
 # Should rebuild the services without errors
 lando rebuild -y
 docker ps --filter label=com.docker.compose.project=landobase | grep landobase_log_1

--- a/plugins/lando-core/tasks/poweroff.js
+++ b/plugins/lando-core/tasks/poweroff.js
@@ -8,10 +8,30 @@ module.exports = lando => {
     command: 'poweroff',
     level: 'engine',
     describe: 'Spins down all lando related containers',
-    run: () => {
-      console.log(chalk.green('NO!! SHUT IT ALL DOWN! Spinning Lando containers down...'));
+    options: {
+      exclude: {
+        describe: 'Exclude containers from one or more apps from being shut down',
+        alias: ['e'],
+        default: [],
+        array: true,
+      },
+    },
+    run: options => {
+      // Alert the user to what we're doing based on if any excludes were provided
+      const message = options.exclude.length
+        ? 'Excluded apps detected. Spinning other Lando containers down... Global containers will be skipped.'
+        : 'NO!! SHUT IT ALL DOWN! Spinning Lando containers down...';
+
+      console.log(chalk.green(message));
+
       // Get all our containers
       return lando.engine.list()
+      // If we have any excludes, filter them and any global containers (e.g. proxy) out
+      .filter(container =>
+        options.exclude.length
+          ? !options.exclude.includes(container.app) && container.app !== '_global_'
+          : true
+      )
       // SHUT IT ALL DOWN
       .each(container => console.log('Bye bye %s ... ', container.name, chalk.green('done')))
       .each(container => lando.engine.stop({id: container.id}))

--- a/plugins/lando-core/tasks/start.js
+++ b/plugins/lando-core/tasks/start.js
@@ -3,6 +3,22 @@
 const chalk = require('chalk');
 const utils = require('./../lib/utils');
 
+// Helper to poweroff existing app, if applicable
+const handleOptionalPoweroff = (lando, options) => {
+  let maybePoweroff;
+  if (options.only) {
+    const _ = require('lodash');
+    const poweroff = _.find(lando.tasks, {command: 'poweroff'});
+    console.log(
+      chalk.green('There can be only one! Preparing to spin down other Lando apps before starting this one...')
+    );
+    maybePoweroff = poweroff.run({exclude: []});
+  } else {
+    maybePoweroff = lando.Promise.resolve('Nothing to see here...');
+  }
+  return maybePoweroff;
+};
+
 module.exports = lando => {
   const table = lando.cli.makeTable();
   return {
@@ -21,27 +37,12 @@ module.exports = lando => {
       const app = lando.getApp(options._app.root);
       // Start it if we can!
       if (app) {
-        let maybePoweroff;
-
-        // Determine if we need to poweroff all other apps before starting this one
-        if (options.only) {
-          const _ = require('lodash');
-          const poweroff = _.find(lando.tasks, {command: 'poweroff'});
-          console.log(
-            chalk.green('There can be only one! Preparing to spin down other Lando apps before starting this one...')
-          );
-          maybePoweroff = poweroff.run({exclude: []});
-        } else {
-          maybePoweroff = lando.Promise.resolve('Nothing to see here...');
-        }
-
         // Wait for the optional poweroff to complete before starting this app
-        maybePoweroff.then(() => {
+        handleOptionalPoweroff(lando, options)
+        .then(() => {
           console.log(chalk.green('Let\'s get this party started! Starting app...'));
         })
-        .then(() =>
-          utils.appToggle(app, 'start', table, lando.cli.makeArt())
-        );
+        .then(() => utils.appToggle(app, 'start', table, lando.cli.makeArt()));
       }
     },
   };

--- a/plugins/lando-core/tasks/start.js
+++ b/plugins/lando-core/tasks/start.js
@@ -8,13 +8,40 @@ module.exports = lando => {
   return {
     command: 'start',
     describe: 'Starts your app',
+    options: {
+      only: {
+        describe: 'Shut down any other running apps before starting this one',
+        alias: ['o'],
+        default: false,
+        boolean: true,
+      },
+    },
     run: options => {
       // Try to get our app
       const app = lando.getApp(options._app.root);
       // Start it if we can!
       if (app) {
-        console.log(chalk.green('Let\'s get this party started! Starting app..'));
-        return utils.appToggle(app, 'start', table, lando.cli.makeArt());
+        let maybePoweroff;
+
+        // Determine if we need to poweroff all other apps before starting this one
+        if (options.only) {
+          const _ = require('lodash');
+          const poweroff = _.find(lando.tasks, {command: 'poweroff'});
+          console.log(
+            chalk.green('There can be only one! Preparing to spin down other Lando apps before starting this one...')
+          );
+          maybePoweroff = poweroff.run({exclude: []});
+        } else {
+          maybePoweroff = lando.Promise.resolve('Nothing to see here...');
+        }
+
+        // Wait for the optional poweroff to complete before starting this app
+        maybePoweroff.then(() => {
+          console.log(chalk.green('Let\'s get this party started! Starting app...'));
+        })
+        .then(() =>
+          utils.appToggle(app, 'start', table, lando.cli.makeArt())
+        );
       }
     },
   };


### PR DESCRIPTION
@pirog, this implements new functionality for two existing Lando core tasks:

1. `lando poweroff --exclude myapp1 --exclude myapp2`
    - Allow users to exclude apps from being spun down
    - Multiple `exclude` flags can be included to skip multiple apps
    - The inclusion of the `exclude` flag will also skip spinning down any global Lando containers (e.g. the proxy), regardless of whether the excluded apps exist and are running
    - A functional test was included for this new flag
2. `lando start --only`
    - If the `only` flag is present, any currently-running apps will be spun down before spinning up the specified app
    - No functional test was included for this new flag, as existing tests seem to be focused on the context of a single app and properly testing this would require spinning up an additional app. Please let me know if there should be a test for this functionality as well, and I'll work on getting one in!

- [x] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/help)
- [x] My code includes a [functional test](https://docs.devwithlando.io/dev/testing.html#functional-tests) if applicable
- [ ] My code includes a [unit test](https://docs.devwithlando.io/dev/testing.html#unit-tests) if applicable
- [x] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [x] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.
