### PR TITLE
Update xdebug query parameter in documentation

### DIFF
--- a/docs/config/php.md
+++ b/docs/config/php.md
@@ -124,7 +124,7 @@ The first part of a pathmap will be the location of your code in the container. 
 #### Troubleshooting Xdebug
 
 ::: tip Problems starting XDEBUG
-If you are visiting your site and xdebug is not triggering, it might be worth appending `?XDEBUG_START_SESSION=LANDO` to your request and seeing if that does the trick.
+If you are visiting your site and xdebug is not triggering, it might be worth appending `?XDEBUG_SESSION_START=LANDO` to your request and seeing if that does the trick.
 :::
 
 If you have set `xdebug: true` in your recipe or service config and run `lando rebuild` but are still having issues getting `xdebug` to work correctly we recommend that you remove `xdebug: true`, run `lando rebuild` and then set the relevant `xdebug` config directly using a custom a `php.ini` (see examples above on how to set a custom config file). Your config file should minimally include something like below.


### PR DESCRIPTION
Thank you so much for contributing code to Lando! If this is your **first time** contributing to Lando we recommend you check out

* [Contributing to Lando](https://docs.devwithlando.io/contrib/contributing.html)
* [Lando Developer Guide](https://docs.devwithlando.io/dev/started.html)

We will get to your PR as soon as we can but in the meantime you might want to check to make sure you have done the following. **The more boxes you can check the easier it will be for us to merge in your changes with confidence**

- [x] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/help)
- [ ] My code includes a [functional test](https://docs.devwithlando.io/dev/testing.html#functional-tests) if applicable
- [ ] My code includes a [unit test](https://docs.devwithlando.io/dev/testing.html#unit-tests) if applicable
- [x] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [x] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

### Documentation update:
- According to the xdebug docs: https://xdebug.org/docs/remote the query parameter should be: `XDEBUG_SESSION_START` rather than `XDEBUG_START_SESSION`.