### PR TITLE
Return to default way of starting memcached container to fix #1827

### DIFF
--- a/plugins/lando-services/services/memcached/builder.js
+++ b/plugins/lando-services/services/memcached/builder.js
@@ -19,13 +19,10 @@ module.exports = {
       options = _.merge({}, config, options);
       const memcached = {
         image: `bitnami/memcached:${options.version}`,
-        command: '/bin/sh -c "chmod +x /launch.sh && /launch.sh"',
+        command: '/entrypoint.sh /run.sh',
         environment: {
           MEMCACHED_CACHE_SIZE: options.mem,
         },
-        volumes: [
-          `${options.confDest}/launch.sh:/launch.sh`,
-        ],
       };
       // Send it downstream
       super(id, options, {services: _.set({}, options.name, memcached)});

--- a/plugins/lando-services/services/memcached/launch.sh
+++ b/plugins/lando-services/services/memcached/launch.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Errors and logz
-set -e
-
-# Try the new entrypoint and then fallback to the older one
-/entrypoint.sh /run.sh || /app-entrypoint.sh /run.sh


### PR DESCRIPTION
- [X] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/help)
- [x] My code includes a [functional test](https://docs.devwithlando.io/dev/testing.html#functional-tests) if applicable
- [x] My code includes a [unit test](https://docs.devwithlando.io/dev/testing.html#unit-tests) if applicable
- [x] My code includes documentation updates if applicable.
- [x] My code passes relevant CI status checks
- [x] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

The way it was in master caused `/launch.sh` to be a directory, not a script.
This replaces the changes from d702d19062d5128cc51bca707abd4331a606a9d0
