### PR TITLE
Restore video in Lando PHPStorm guide

### DIFF
--- a/docs/guides/lando-phpstorm.md
+++ b/docs/guides/lando-phpstorm.md
@@ -9,6 +9,10 @@ description: Learn how to configure xdebug in Lando using PhpStorm.
 [PhpStorm](https://www.jetbrains.com/phpstorm/) is a popular code IDE for PHP
 and Drupal development. This video tutorial shows you how to set up PhpStorm with Xdebug.
 
+{% youtube %}	
+https://www.youtube.com/watch?v=sHNJxx0L9r0	
+{% endyoutube %}
+
 If you’ve a local php installation (for example php 7.1 installed with homebrew on macOS) that listens on port 9000 you may need to change the containers php.ini port specification to another port (i.e. `xdebug.remote_port=9001`) and tell phpstorm to listen on that port. See also [Debugging Drupal 8 with PHPstorm and Lando on your Mac](https://www.isovera.com/blog/debugging-drupal-8-phpstorm-and-lando-your-mac).
 
 ## Debugging Drush Commands


### PR DESCRIPTION
The text mentions a video tutorial, but the video link was removed in commit 1efa15e998bbc96cc4fc25f56227b756b5ff7d1b