### PR TITLE
Remove preview=true from GH sponsor links

### DIFF
--- a/docs/contrib/sponsor-benefits.md
+++ b/docs/contrib/sponsor-benefits.md
@@ -22,7 +22,7 @@ Benefits start at the "Herald" level (currently the $9/month individual sponsor 
 
 If you know an organization that needs a local development solution, let us know by becoming an [upseller](./upseller-intro.md).
 
-For the official list of benefits check out our [GitHub Sponsors](https://github.com/sponsors/lando?preview=true) page.
+For the official list of benefits check out our [GitHub Sponsors](https://github.com/sponsors/lando) page.
 
 ## Future Benefits
 

--- a/website/.vuepress/theme/components/SponsorshipTiers.vue
+++ b/website/.vuepress/theme/components/SponsorshipTiers.vue
@@ -34,7 +34,7 @@ export default {
           ],
           color: 'blue',
           level: 'developer',
-          link: 'https://github.com/sponsors/lando?preview=true',
+          link: 'https://github.com/sponsors/lando',
           price: '4',
         },
         {
@@ -48,7 +48,7 @@ export default {
           ],
           color: 'green',
           level: 'team',
-          link: 'https://github.com/sponsors/lando?preview=true',
+          link: 'https://github.com/sponsors/lando',
           price: '99',
         },
         {

--- a/website/.vuepress/theme/components/SponsorshipTiers.vue
+++ b/website/.vuepress/theme/components/SponsorshipTiers.vue
@@ -62,7 +62,7 @@ export default {
           link: 'https://lando.dev/contact/',
           linkText: 'Contact Us',
           otherLinks: [
-            {name: 'Plan Details', url: 'https://github.com/sponsors/lando?preview=true'},
+            {name: 'Plan Details', url: 'https://github.com/sponsors/lando'},
             {name: 'Read More', url: 'https://blog.lando.dev/2020/02/06/why-your-pass-should-sponsor-lando/'},
           ],
           price: '999',

--- a/website/.vuepress/theme/components/Tier.vue
+++ b/website/.vuepress/theme/components/Tier.vue
@@ -54,7 +54,7 @@ export default {
     },
     link: {
       type: String,
-      default: 'https://github.com/sponsors/lando?preview=true',
+      default: 'https://github.com/sponsors/lando',
     },
     linkText: {
       type: String,

--- a/website/.vuepress/theme/layouts/Sponsor.vue
+++ b/website/.vuepress/theme/layouts/Sponsor.vue
@@ -22,7 +22,7 @@
         <Heralds />
       </div>
       <div class="smaller-inner sponsor-button">
-        <a class="button big pink sponsor" href="https://github.com/sponsors/lando?preview=true" target="_blank">
+        <a class="button big pink sponsor" href="https://github.com/sponsors/lando" target="_blank">
           <i class="devicon-github-plain"></i>  Sponsor
         </a>
       </div>


### PR DESCRIPTION
Removes the preview=true on the sponsorship links for github

Thank you so much for contributing code to Lando! If this is your **first time** contributing to Lando we recommend you check out

* [Contributing to Lando](https://docs.devwithlando.io/contrib/contributing.html)
* [Lando Developer Guide](https://docs.devwithlando.io/dev/started.html)

We will get to your PR as soon as we can but in the meantime you might want to check to make sure you have done the following. **The more boxes you can check the easier it will be for us to merge in your changes with confidence**

- [ ] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/help)
- [ ] My code includes a [functional test](https://docs.devwithlando.io/dev/testing.html#functional-tests) if applicable
- [ ] My code includes a [unit test](https://docs.devwithlando.io/dev/testing.html#unit-tests) if applicable
- [ ] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.
