### PR TITLE
closes #988 - increase maximum number of returned sites to 5000

### DIFF
--- a/plugins/lando-pantheon/lib/client.js
+++ b/plugins/lando-pantheon/lib/client.js
@@ -82,7 +82,7 @@ module.exports = class PantheonApiClient {
   getSites() {
     // Call to get user sites
     const pantheonUserSites = () => {
-      const getSites = ['users', _.get(this.session, 'user_id'), 'memberships', 'sites'];
+      const getSites = ['users', _.get(this.session, 'user_id'), 'memberships', 'sites?limit=5000'];
       return pantheonRequest(this.request, this.log, 'get', getSites)
       .then(sites => _.map(sites, (site, id) => _.merge(site, site.site)));
     };
@@ -92,7 +92,7 @@ module.exports = class PantheonApiClient {
       return pantheonRequest(this.request, this.log, 'get', getOrgs)
       .map(org => {
         if (org.role !== 'unprivileged') {
-          return pantheonRequest(this.request, this.log, 'get', ['organizations', org.id, 'memberships', 'sites'])
+          return pantheonRequest(this.request, this.log, 'get', ['organizations', org.id, 'memberships', 'sites?limit=5000'])
           .map(site => _.merge(site, site.site));
         }
       })

--- a/plugins/lando-pantheon/lib/client.js
+++ b/plugins/lando-pantheon/lib/client.js
@@ -92,7 +92,8 @@ module.exports = class PantheonApiClient {
       return pantheonRequest(this.request, this.log, 'get', getOrgs)
       .map(org => {
         if (org.role !== 'unprivileged') {
-          return pantheonRequest(this.request, this.log, 'get', ['organizations', org.id, 'memberships', 'sites?limit=5000'])
+          return pantheonRequest(this.request, this.log, 'get',
+          ['organizations', org.id, 'memberships', 'sites?limit=5000'])
           .map(site => _.merge(site, site.site));
         }
       })


### PR DESCRIPTION
This HTTP GET parameter (limit) allows Pantheon's API to return more than the default number of results. I'm not actually sure if there is a hard upper bound but I definitely see a difference between the default and adding a limit of 5000.

This should resolve #988