### PR TITLE
Updates wordpress.conf.tpl to support WordPress multisite

### DIFF
--- a/api/data/contributors.yml
+++ b/api/data/contributors.yml
@@ -50,3 +50,13 @@
   title: Contributor
   pic: 'https://s.gravatar.com/avatar/b94fb6501cf666caf2b8f47d4e4e3b1c'
   id: 433bd1bd859bb74aa4c7be9f0acd798692d49b62
+- name: Reid Linker
+  role:
+    - Code
+  bio: 'Father, husband, gamer, geek. Not necessarily in that order. ISFJ.'
+  location: 'Charlotte, NC'
+  github: screid123
+  twitter: screid123
+  title: Contributor
+  pic: 'https://www.gravatar.com/avatar/210f5d93d1ab748f8f8e065403bfdbd4'
+  id: 227467db7bcdb7dd20095193fe69b92891a0be86

--- a/docs/help/2020-changelog.md
+++ b/docs/help/2020-changelog.md
@@ -10,3 +10,4 @@
 **ALSO, STILL, SERIOUSLY, READ THE DOCS!: https://docs.lando.dev/**
 
 * Upgraded to Docker Desktop 2.2.0.0
+* Added support for WordPress Site Networks (Multisite) to Pantheon recipe.

--- a/plugins/lando-pantheon/recipes/pantheon/wordpress.conf.tpl
+++ b/plugins/lando-pantheon/recipes/pantheon/wordpress.conf.tpl
@@ -123,6 +123,20 @@ server {
         error_page 301 =301 $client_scheme://$host$uri/$is_args$args;
     }
 
+    # Rewrite multisite '.../wp-.*' and '.../*.php'.
+    # Because even if the site is in a subdirectory at http://site.com/site-a/
+    # requests for the wp-admin, or other specific php files, need to go to the docroot.
+    if (!-e $request_filename) {
+        rewrite /wp-admin$ $scheme://$host$uri/ permanent;
+        rewrite ^/[_0-9a-zA-Z-]+(/wp-.*) $1 last;
+        rewrite ^/[_0-9a-zA-Z-]+(/.*\.php)$ $1 last;
+    }
+    # Legacy site network files support.
+    location ~ ^/wp-content/blogs.dir/([_0-9a-zA-Z-]+)/files/(.*)$ {
+        try_files /wp-content/blogs.dir/$1/files/$2 /wp-includes/ms-files.php?file=$2 ;
+        access_log off; log_not_found off; expires max;
+    }
+
     location @cleanurl {
         rewrite ^/(.*)$ /index.php?q=$1 last;
     }


### PR DESCRIPTION
## Adds missing rules from Pantheon nginx config to support WordPress multisite (site network). 

After some research and digging into the Pantheon recipe, I was able to get a WordPress site network running locally in Lando. I "hacked" my local by updating the `appserver_nginx` container to use modified TPLs (see below). This update basically adds the following to the `wordpress.conf.tpl` to support the rewrite rule for multisite (which I found by manually diffing the NGINX config I downloaded from our Pantheon instance via SFTP; lines ~379-392 in `nginx.conf`):

```
# Rewrite multisite '.../wp-.*' and '.../*.php'.
# Because even if the site is in a subdirectory at http://site.com/site-a/
# requests for the wp-admin, or other specific php files, need to go to the docroot.
if (!-e $request_filename) {
    rewrite /wp-admin$ $scheme://$host$uri/ permanent;
    rewrite ^/[_0-9a-zA-Z-]+(/wp-.*) $1 last;
    rewrite ^/[_0-9a-zA-Z-]+(/.*\.php)$ $1 last;
}
# Legacy site network files support.
location ~ ^/wp-content/blogs.dir/([_0-9a-zA-Z-]+)/files/(.*)$ {
    try_files /wp-content/blogs.dir/$1/files/$2 /wp-includes/ms-files.php?file=$2 ;
    access_log off; log_not_found off; expires max;
}
```

### References that led me down the rabbit hole:
- https://www.nginx.com/resources/wiki/start/topics/recipes/wordpress/#rewrite-rules-for-multisite
- https://docs.lando.dev/config/nginx.html#configuration
- https://docs.lando.dev/config/pantheon.html#configuration

### Background
Initially, I grabbed the `nginx.conf.tpl` and `wordpress.conf.tpl` from the [Pantheon recipe](https://github.com/lando/lando/tree/master/plugins/lando-pantheon/recipes/pantheon) and put them in the root `private` directory (which is protected in Pantheon environment). I added the same changes to `wordpress.conf.tpl` as this PR, and then updated `lando.yml` with the following:
```yaml
services:
  appserver_nginx:
    type: nginx
    config:
      server: 'private/config/nginx.conf.tpl'
      vhosts: 'private/config/wordpress.conf.tpl'
```
I performed a `lando rebuild` and it worked. Figured updating the source TPL might help other folks out (#157 and #1425 to name a couple). 😃 

---

We will get to your PR as soon as we can but in the meantime you might want to check to make sure you have done the following. **The more boxes you can check the easier it will be for us to merge in your changes with confidence**

- [x] My code includes the latest code from the `master` branch
- [x] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/help)
- [ ] My code includes a [functional test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes a [unit test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.
