### PR TITLE
Update proper way to add a local Drush uri setting

### DIFF
--- a/docs/config/drupal8.md
+++ b/docs/config/drupal8.md
@@ -200,10 +200,14 @@ lando drush uli
 
 This happens because it is actually a difficult problem for Lando to 100% know the canonical URL or service that is serving your application. However you can set up your environment so that commands like `lando drush uli` return the proper URL.
 
-Create or edit the relevant `settings.php` file and add these lines. Note that you may need to specify a port depending on your Lando installation. You can run `lando info` to see if your URLs use explicit ports or not.
+Set a specific local drush uri value by adding a setting for DRUSH_OPTIONS_URI in the relevant service. You will need to run `lando rebuild` after adding this setting. 
 
-```php
-$base_url = "http://mysite.lndo.site:PORT_IF_NEEDED"
+```
+services:
+  appserver:
+    overrides:
+      environment:
+        DRUSH_OPTIONS_URI: "https://mysite.lndo.site"
 ```
 
 #### Aliases


### PR DESCRIPTION
The old method of adding a `$base_url` does not work.

Thank you so much for contributing code to Lando! If this is your **first time** contributing to Lando we recommend you first check our [Getting Involved](https://docs.lando.dev/contrib/contributing.html) docs.

It may also be useful to check the below documentation based on what you are trying to do:

* [Adding code to Lando](https://docs.lando.dev/contrib/contrib-intro.html)
* [Updating documentation](https://docs.lando.dev/contrib/contrib-intro.html)
* [Working on DevOps](https://docs.lando.dev/contrib/contrib-intro.html)
* [Working on Lando's auxiliary services eg websites, apis, etc](https://docs.lando.dev/contrib/contrib-intro.html)
* [Writing Lando Guides](https://docs.lando.dev/contrib/guides-intro.html)
* [Writing Lando blog posts](https://docs.lando.dev/contrib/blogging-intro.html)

We will get to your PR as soon as we can but in the meantime you might want to check to make sure you have done the following. **The more boxes you can check the easier it will be for us to merge in your changes with confidence**

- [x] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/help)
- [ ] My code includes a [functional test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes a [unit test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [x] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

