### PR TITLE
Be nicer to sensitive folks like @q0rban: remove smirk from lando restart

### DIFF
--- a/lib/art.js
+++ b/lib/art.js
@@ -51,7 +51,7 @@ exports.appRebuild = ({name, phase = 'pre'} = {}) => {
 exports.appRestart = ({name, phase = 'pre'} = {}) => {
   switch (phase) {
     case 'pre':
-      return chalk.cyan('Stopping your app... just so we can start it up again ¯\\_(ツ)_/¯');
+      return chalk.cyan('Stopping and restarting your app...Shiny!');
     case 'post':
       return exports.appStart({name, phase});
   }


### PR DESCRIPTION
This pull request changes the language that lando displays when running `lando restart`. 

The current language:

`Stopping your app... just so we can start it up again ¯\_(ツ)_/¯`

I'm probably sensitive, but this language makes me feel like lando is poking fun at me for choosing `restart`, and that I should have chosen a better course of action. I changed it to the following, but am open to whatever:

`Stopping and restarting your app...Shiny!`


- [X] My code includes the latest code from the `master` branch
- [ ] ~My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/help)~
- [ ] ~My code includes a [functional test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable~
- [ ] ~My code includes a [unit test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable~
- [ ] ~My code includes documentation updates if applicable.~
- [ ] My code passes relevant CI status checks
- [x] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

