### PR TITLE
Support phpmyadmin 5.0

### DIFF
--- a/docs/config/phpmyadmin.md
+++ b/docs/config/phpmyadmin.md
@@ -12,6 +12,7 @@ You can easily add it to your Lando app by adding an entry to the [services](./.
 
 ## Supported versions
 
+*   [5.0](https://hub.docker.com/r/phpmyadmin/phpmyadmin/)
 *   **[4.7](https://hub.docker.com/r/phpmyadmin/phpmyadmin/)** **(default)**
 *   [4.6](https://hub.docker.com/r/phpmyadmin/phpmyadmin/)
 *   [custom](./../config/services.md#advanced)

--- a/docs/help/2020-changelog.md
+++ b/docs/help/2020-changelog.md
@@ -5,6 +5,7 @@
 Lando is **free** and **open source** software that relies on contributions from developers like you! If you like Lando then help us spend more time making, updating and supporting it by [contributing](https://github.com/sponsors/lando).
 
 * Fixed bug causing crash on `macOS` if Docker is not installed first
+* Added support for `phpmyadmin` `5.0` [#2062](https://github.com/lando/lando/issues/2062)
 
 **ALSO, STILL, SERIOUSLY, READ THE DOCS!: https://docs.lando.dev/**
 

--- a/plugins/lando-services/services/phpmyadmin/builder.js
+++ b/plugins/lando-services/services/phpmyadmin/builder.js
@@ -10,7 +10,7 @@ module.exports = {
     version: '4.7',
     supported: ['5.0', '4.7', '4.6'],
     pinPairs: {
-      '5.0': 'phpmyadmin/phpmyadmin:5.0.1-fpm-alpine',
+      '5.0': 'phpmyadmin/phpmyadmin:5.0.2',
     },
     confSrc: __dirname,
     hosts: ['database'],

--- a/plugins/lando-services/services/phpmyadmin/builder.js
+++ b/plugins/lando-services/services/phpmyadmin/builder.js
@@ -8,7 +8,10 @@ module.exports = {
   name: 'phpmyadmin',
   config: {
     version: '4.7',
-    supported: ['4.7', '4.6'],
+    supported: ['5.0', '4.7', '4.6'],
+    pinPairs: {
+      '5.0': 'phpmyadmin/phpmyadmin:5.0.1-fpm-alpine',
+    },
     confSrc: __dirname,
     hosts: ['database'],
     remoteFiles: {
@@ -32,7 +35,10 @@ module.exports = {
           PMA_PASSWORD: '',
         },
         ports: ['80'],
-        command: '/run.sh phpmyadmin',
+        command: '/launch.sh',
+        volumes: [
+          `${options.confDest}/launch.sh:/launch.sh`,
+        ],
       };
       // Add some info
       options.info = {backends: options.hosts};

--- a/plugins/lando-services/services/phpmyadmin/launch.sh
+++ b/plugins/lando-services/services/phpmyadmin/launch.sh
@@ -4,5 +4,5 @@
 set -e
 
 # Try the new entrypoint and then fallback to the older one
-/docker-entrypoint.sh php-fpm \
+/docker-entrypoint.sh apache2-foreground \
   || /run.sh phpmyadmin

--- a/plugins/lando-services/services/phpmyadmin/launch.sh
+++ b/plugins/lando-services/services/phpmyadmin/launch.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Errors and logz
+set -e
+
+# Try the new entrypoint and then fallback to the older one
+/docker-entrypoint.sh php-fpm \
+  || /run.sh phpmyadmin


### PR DESCRIPTION
Support `phpmyadmin 5.0` due to login problems with `mysql:8.0` - see: https://github.com/lando/lando/issues/2062

- [x] My code includes the latest code from the `master` branch
- [x] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/help)
- [ ] My code includes a [functional test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes a [unit test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [x] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer]

It is the first time that I am contributing to Lando.
Unfortunately, I can't connect always to the container via traefik, although I think everything should be fine. Maybe someone can support me, what is missing in my PR.
Or is it a problem with lando.dev and Windows :-(