### PR TITLE
fix contrib-plugins.md links

### DIFF
--- a/docs/basics/basics.md
+++ b/docs/basics/basics.md
@@ -89,7 +89,7 @@ There are various ways to craft your Landofile but we've found and observed a st
 3. Define more complex [tooling](./../config/tooling.md) and [events](./../config/events.md) to simplify difficult command patterns and automate common tasks.
 4. Add in some [build steps](./../config/services.md#build-steps) to further automate setting your services up or to mix in additional project dependencies.
 5. Define [custom services](./../config/compose.md) as a catch all for anything else you need.
-6. Create [custom recipes or services](./../contrib/plugins.md) to lock down your new power tools.
+6. Create [custom recipes or services](./../contrib-plugins.md) to lock down your new power tools.
 7. Rinse and repeat.
 
 ## You have some examples?

--- a/docs/config/recipes.md
+++ b/docs/config/recipes.md
@@ -8,7 +8,7 @@ Recipes are Lando's highest level abstraction and they contain common combinatio
 
 ## Usage
 
-You can use the top-level `recipe` config in your [Landofile](./lando.md) to select a recipe. Note that you will need to select one of the [supported recipes](#supported-recipes) or [create your own](./../contrib/plugins.md).
+You can use the top-level `recipe` config in your [Landofile](./lando.md) to select a recipe. Note that you will need to select one of the [supported recipes](#supported-recipes) or [create your own](./../contrib-plugins.md).
 
 For example this will use the [Drupal 8](./drupal8.md) recipe.
 

--- a/docs/config/services.md
+++ b/docs/config/services.md
@@ -22,7 +22,7 @@ services:
 
 `myservice` in the example above can actully be set to anything the user wants but common conventions are things like `appserver`, `index`, `cache`, `database` or `kanye`.
 
-Note that you will need to set the `type` and its optional `version` to be either one of the [supported services](#supported-services) below or as defined in one you [create your own](./../contrib/plugins.md).
+Note that you will need to set the `type` and its optional `version` to be either one of the [supported services](#supported-services) below or as defined in one you [create your own](./../contrib-plugins.md).
 
 Each service also contains a bunch of its own configuartion options. As such we *highly recommend* you check out the documentation for each service. For example here are some of the configuration options available to the `php` service.
 

--- a/docs/config/tooling.md
+++ b/docs/config/tooling.md
@@ -189,7 +189,7 @@ tooling:
 
 ### Options driven tooling
 
-You can also define your own options for use in tooling. These options follow the same spec as [Lando tasks](./../contrib/plugins.md#tasks) and are generally used in combination with an underlying script.
+You can also define your own options for use in tooling. These options follow the same spec as [Lando tasks](./../contrib-plugins.md#tasks) and are generally used in combination with an underlying script.
 
 Note that the options interface just provides a way to define and then inject options into a given command. It is up to the user to make sure the underlying command or script knows what to do with such options. Note that if you use interactive options you need to set `level: app` as below.
 


### PR DESCRIPTION
Just fixing some broken links in the docs. :)

- [x] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/help)
- [ ] My code includes a [functional test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes a [unit test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [x] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

