### PR TITLE
Missing -s in line 35

### DIFF
--- a/docs/config/ssh.md
+++ b/docs/config/ssh.md
@@ -32,5 +32,5 @@ lando logs -s appserver
 
 # Check the .ssh config for a given service
 # Obviously replace appserver with the service you are interested in
-lando ssh appserver -c "cat /etc/ssh/ssh_config"
+lando ssh -s appserver -c "cat /etc/ssh/ssh_config"
 ```


### PR DESCRIPTION
Without the -s the lando ssh command for the appserver config edit won't work.

Thank you so much for contributing code to Lando! If this is your **first time** contributing to Lando we recommend you first check our [Getting Involved](https://docs.lando.dev/contrib/contributing.html) docs.

It may also be useful to check the below documentation based on what you are trying to do:

* [Adding code to Lando](https://docs.lando.dev/contrib/contrib-intro.html)
* [Updating documentation](https://docs.lando.dev/contrib/contrib-intro.html)
* [Working on DevOps](https://docs.lando.dev/contrib/contrib-intro.html)
* [Working on Lando's auxiliary services eg websites, apis, etc](https://docs.lando.dev/contrib/contrib-intro.html)
* [Writing Lando Guides](https://docs.lando.dev/contrib/guides-intro.html)
* [Writing Lando blog posts](https://docs.lando.dev/contrib/blogging-intro.html)

We will get to your PR as soon as we can but in the meantime you might want to check to make sure you have done the following. **The more boxes you can check the easier it will be for us to merge in your changes with confidence**

- [ ] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/help)
- [ ] My code includes a [functional test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes a [unit test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

