### PR TITLE
Fix bad twitter URLs (should be .com, not .org)

### DIFF
--- a/docs/contrib/evangelist-intro.md
+++ b/docs/contrib/evangelist-intro.md
@@ -13,9 +13,9 @@ Because Lando is a free and open source project without :unicorn: money we rely 
 While you should _do you_ and evengelize in the way that best suits you here are things some of our more successful advocates do:
 
 * Present, talk or train about Lando or Lando-adjacent materials at conference, camps, meetups, etc and to post those events at <https://events.lando.dev>
-* Retweet Lando content, tweet directly at [@devwithlando](https://twitter.org/devwithlando) or engage in local dev or DevOps related twitter threads
+* Retweet Lando content, tweet directly at [@devwithlando](https://twitter.com/devwithlando) or engage in local dev or DevOps related twitter threads
 * Troll local development blog content and mention Lando in the comments if applicable
-* Get friends, colleagues, spouses, partners, pets, grandparents, former roommates, etc to follow us [@devwithlando](https://twitter.org/devwithlando) and [star our project on GitHub](https://github.com/lando/lando).
+* Get friends, colleagues, spouses, partners, pets, grandparents, former roommates, etc to follow us [@devwithlando](https://twitter.com/devwithlando) and [star our project on GitHub](https://github.com/lando/lando).
 * Buy a Vagrant or MAMP user a :beer: and hit them with some sweet, sweet [talking points](./talking-points.md)
 
 ::: tip Evangelism need not be directly Lando related!


### PR DESCRIPTION
This is just a minor documentation update to fix two bad twitter URLs.
