### PR TITLE
Issue #1987: Set PATH_INFO and PATH_TRANSLATED for Pantheon Nginx containers

### DIFF
--- a/docs/help/2020-changelog.md
+++ b/docs/help/2020-changelog.md
@@ -4,6 +4,7 @@
 
 Lando is **free** and **open source** software that relies on contributions from developers like you! If you like Lando then help us spend more time making, updating and supporting it by [contributing](https://github.com/sponsors/lando).
 
+* Set `PATH_INFO` and `PATH_TRANSLATION` fastcgi params for Pantheon [#2105](https://github.com/lando/lando/pull/2105)
 * Added support for `go` versions `1.12-1.14`,
 * Added support for `solr` `8` [#1765](https://github.com/lando/lando/pull/1765)
 * Added new `solr` `7` minor versions [#1765](https://github.com/lando/lando/pull/1765)

--- a/examples/pantheon-drupal7/README.md
+++ b/examples/pantheon-drupal7/README.md
@@ -27,7 +27,6 @@ lando start
 # Should pull down database and files for our drupal7 site
 cd drupal7
 lando pull --code none --database dev --files dev --rsync
-
 ```
 
 Verification commands

--- a/examples/pantheon-drupal7/README.md
+++ b/examples/pantheon-drupal7/README.md
@@ -87,7 +87,7 @@ lando ssh -c "env" | grep TERMINUS_USER | grep landobot@devwithlando.io
 # Should load proper nginx fastcgi params
 cp test.php drupal7
 cd drupal7
-lando ssh -s appserver -c "curl http://appserver_nginx/test.php" | grep "PATH_INFO"
+curl http://landobot-drupal7.lndo.site/test.php | grep "PATH_INFO"
 rm test.php
 
 # Should not set any 8983 perms

--- a/examples/pantheon-drupal7/README.md
+++ b/examples/pantheon-drupal7/README.md
@@ -27,6 +27,7 @@ lando start
 # Should pull down database and files for our drupal7 site
 cd drupal7
 lando pull --code none --database dev --files dev --rsync
+
 ```
 
 Verification commands
@@ -82,6 +83,12 @@ lando ssh -c "env" | grep PRESSFLOW_SETTINGS | grep pantheon
 lando ssh -c "env" | grep TERMINUS_ENV | grep dev
 lando ssh -c "env" | grep TERMINUS_SITE | grep landobot-drupal7
 lando ssh -c "env" | grep TERMINUS_USER | grep landobot@devwithlando.io
+
+# Should load proper nginx fastcgi params
+cp test.php drupal7
+cd drupal7
+lando ssh -s appserver -c "curl http://appserver_nginx/test.php/foo/bar.php | grep PATH_INFO"
+rm test.php
 
 # Should not set any 8983 perms
 cd drupal7

--- a/examples/pantheon-drupal7/README.md
+++ b/examples/pantheon-drupal7/README.md
@@ -87,7 +87,7 @@ lando ssh -c "env" | grep TERMINUS_USER | grep landobot@devwithlando.io
 # Should load proper nginx fastcgi params
 cp test.php drupal7
 cd drupal7
-lando ssh -s appserver -c "curl http://appserver_nginx/test.php/foo/bar.php | grep PATH_INFO"
+lando ssh -s appserver -c "curl http://appserver_nginx/test.php" | grep "PATH_INFO"
 rm test.php
 
 # Should not set any 8983 perms

--- a/examples/pantheon-drupal7/test.php
+++ b/examples/pantheon-drupal7/test.php
@@ -1,0 +1,1 @@
+<?php var_export($_SERVER) ?>

--- a/examples/pantheon-drupal7/test.php
+++ b/examples/pantheon-drupal7/test.php
@@ -1,1 +1,1 @@
-<?php var_export($_SERVER) ?>
+<?php var_export($_SERVER); ?>

--- a/plugins/lando-pantheon/recipes/pantheon/builder.js
+++ b/plugins/lando-pantheon/recipes/pantheon/builder.js
@@ -8,6 +8,44 @@ const push = require('./../../lib/push');
 const change = require('./../../lib/switch');
 const utils = require('./../../lib/utils');
 
+const overrideAppserver = options => {
+  // Use our custom pantheon images
+  options.services.appserver.overrides.image = `devwithlando/pantheon-appserver:${options.php}-2`;
+  // Add in the prepend.php
+  // @TODO: this throws a weird DeprecationWarning: 'root' is deprecated, use 'global' for reasons not immediately clear
+  // So we are doing this a little weirdly to avoid hat until we can track things down better
+  options.services.appserver.overrides.volumes.push(`${options.confDest}/prepend.php:/srv/includes/prepend.php`);
+  // Mount our custom fastcgi_params file to inject Pantheon goodness into nginx.
+  options.services.appserver.overrides.volumes.push(
+    `${options.confDest}/fastcgi_params:/srv/includes/fastcgi_params`
+  );
+  // Add in our environment
+  options.services.appserver.overrides.environment = utils.getPantheonEnvironment(options);
+  return options;
+};
+
+const setTooling = (options, tokens) => {
+  // Add in push/pull/switch
+  options.tooling.pull = pull.getPantheonPull(options, tokens);
+  options.tooling.push = push.getPantheonPush(options, tokens);
+  options.tooling.switch = change.getPantheonSwitch(options, tokens);
+  // Add in the framework-correct tooling
+  options.tooling = _.merge({}, options.tooling, utils.getPantheonTooling(options.framework));
+  return options;
+};
+
+const setBuildSteps = options => {
+  // Add in our pantheon script
+  // NOTE: We do this here instead of in /scripts because we need to guarantee
+  // it runs before the other build steps so it can reset our CA correctly
+  options.build = utils.getPantheonBuildSteps(options.framework).concat(options.build);
+  options.build_root.push('/helpers/pantheon.sh');
+  options.build.push('/helpers/auth.sh');
+  options.run_root.push('/helpers/binding.sh');
+  // Add in the framework-correct build steps
+  return options;
+};
+
 /*
  * Build Drupal 7
  */
@@ -52,24 +90,7 @@ module.exports = {
       options.database = 'mariadb:10.1';
       // Set correct things based on framework
       options.defaultFiles.vhosts = `${options.framework}.conf.tpl`;
-      // Use our custom pantheon images
-      options.services.appserver.overrides.image = `devwithlando/pantheon-appserver:${options.php}-2`;
-      // Add in the prepend.php
-      // @TODO: this throws a weird DeprecationWarning: 'root' is deprecated, use 'global' for reasons not immediately clear
-      // So we are doing this a little weirdly to avoid hat until we can track things down better
-      options.services.appserver.overrides.volumes.push(`${options.confDest}/prepend.php:/srv/includes/prepend.php`);
-      // Mount our custom fastcgi_params file to inject Pantheon goodness into nginx.
-      options.services.appserver.overrides.volumes.push(
-        `${options.confDest}/fastcgi_params:/srv/includes/fastcgi_params`
-      );
-      // Add in our environment
-      options.services.appserver.overrides.environment = utils.getPantheonEnvironment(options);
-      // Add in our pantheon script
-      // NOTE: We do this here instead of in /scripts because we need to guarantee
-      // it runs before the other build steps so it can reset our CA correctly
-      options.build_root.push('/helpers/pantheon.sh');
-      options.build.push('/helpers/auth.sh');
-      options.run_root.push('/helpers/binding.sh');
+      options = overrideAppserver(options);
       // Add in cache if applicable
       if (options.cache) options = _.merge({}, options, utils.getPantheonCache());
       // Add in edge if applicable
@@ -77,16 +98,9 @@ module.exports = {
       // Add in index if applicable
       if (options.index) options = _.merge({}, options, utils.getPantheonIndex());
 
-      // Add in the framework-correct tooling
-      options.tooling = _.merge({}, options.tooling, utils.getPantheonTooling(options.framework));
-      // Add in the framework-correct build steps
-      options.build = utils.getPantheonBuildSteps(options.framework).concat(options.build);
-
-      // Add in push/pull/switch
       const tokens = utils.sortTokens(options._app.pantheonTokens, options._app.terminusTokens);
-      options.tooling.pull = pull.getPantheonPull(options, tokens);
-      options.tooling.push = push.getPantheonPush(options, tokens);
-      options.tooling.switch = change.getPantheonSwitch(options, tokens);
+      options = setTooling(options, tokens);
+      options = setBuildSteps(options);
 
       // @TODO: do we still need a depends on for the index for certs shit?
       // Set the appserver to depend on index start up so we know our certs will be there

--- a/plugins/lando-pantheon/recipes/pantheon/builder.js
+++ b/plugins/lando-pantheon/recipes/pantheon/builder.js
@@ -58,6 +58,10 @@ module.exports = {
       // @TODO: this throws a weird DeprecationWarning: 'root' is deprecated, use 'global' for reasons not immediately clear
       // So we are doing this a little weirdly to avoid hat until we can track things down better
       options.services.appserver.overrides.volumes.push(`${options.confDest}/prepend.php:/srv/includes/prepend.php`);
+      // Mount our custom fastcgi_params file to inject Pantheon goodness into nginx.
+      options.services.appserver.overrides.volumes.push(
+        `${options.confDest}/fastcgi_params:/srv/includes/fastcgi_params`
+      );
       // Add in our environment
       options.services.appserver.overrides.environment = utils.getPantheonEnvironment(options);
       // Add in our pantheon script

--- a/plugins/lando-pantheon/recipes/pantheon/drupal.conf.tpl
+++ b/plugins/lando-pantheon/recipes/pantheon/drupal.conf.tpl
@@ -149,7 +149,7 @@ server {
         fastcgi_intercept_errors on;
         fastcgi_pass fpm:9000;
         fastcgi_index index.php;
-        include fastcgi_params;
+        include /srv/includes/fastcgi_params;
         # Allow SimpleSamlPHP to work by settig PATH_INFO, etc
         fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
         fastcgi_param SCRIPT_FILENAME "{{LANDO_WEBROOT}}$fastcgi_script_name";
@@ -172,7 +172,7 @@ server {
         fastcgi_intercept_errors on;
         fastcgi_pass fpm:9000;
         fastcgi_index index.php;
-        include fastcgi_params;
+        include /srv/includes/fastcgi_params;
         # Allow SimpleSamlPHP to work by settig PATH_INFO, etc
         fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
         fastcgi_param SCRIPT_FILENAME "{{LANDO_WEBROOT}}$fastcgi_script_name";

--- a/plugins/lando-pantheon/recipes/pantheon/drupal8.conf.tpl
+++ b/plugins/lando-pantheon/recipes/pantheon/drupal8.conf.tpl
@@ -150,7 +150,7 @@ server {
         fastcgi_intercept_errors on;
         fastcgi_pass fpm:9000;
         fastcgi_index index.php;
-        include fastcgi_params;
+        include /srv/includes/fastcgi_params;
         # Allow SimpleSamlPHP to work by settig PATH_INFO, etc
         fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
         fastcgi_param SCRIPT_FILENAME "{{LANDO_WEBROOT}}$fastcgi_script_name";
@@ -172,7 +172,7 @@ default_charset=\"UTF-8\"";
         fastcgi_intercept_errors on;
         fastcgi_pass fpm:9000;
         fastcgi_index index.php;
-        include fastcgi_params;
+        include /srv/includes/fastcgi_params;
         # Allow SimpleSamlPHP to work by settig PATH_INFO, etc
         fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
         fastcgi_param SCRIPT_FILENAME "{{LANDO_WEBROOT}}$fastcgi_script_name";
@@ -195,7 +195,7 @@ default_charset=\"UTF-8\"";
         fastcgi_intercept_errors on;
         fastcgi_pass fpm:9000;
         fastcgi_index index.php;
-        include fastcgi_params;
+        include /srv/includes/fastcgi_params;
         # Allow SimpleSamlPHP to work by settig PATH_INFO, etc
         fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
         fastcgi_param SCRIPT_FILENAME "{{LANDO_WEBROOT}}$fastcgi_script_name";

--- a/plugins/lando-pantheon/recipes/pantheon/fastcgi_params
+++ b/plugins/lando-pantheon/recipes/pantheon/fastcgi_params
@@ -1,0 +1,30 @@
+ fastcgi_param  QUERY_STRING       $query_string;
+  fastcgi_param  REQUEST_METHOD     $request_method;
+  fastcgi_param  CONTENT_TYPE       $content_type;
+  fastcgi_param  CONTENT_LENGTH     $content_length;
+
+  fastcgi_param  SCRIPT_NAME        $fastcgi_script_name;
+  fastcgi_param  REQUEST_URI        $request_uri;
+  fastcgi_param  DOCUMENT_URI       $document_uri;
+  fastcgi_param  DOCUMENT_ROOT      $document_root;
+  fastcgi_param  SERVER_PROTOCOL    $server_protocol;
+
+  fastcgi_param  GATEWAY_INTERFACE  CGI/1.1;
+  fastcgi_param  SERVER_SOFTWARE    nginx/$nginx_version;
+
+  fastcgi_param  REMOTE_ADDR        $remote_addr;
+  fastcgi_param  REMOTE_PORT        $remote_port;
+  fastcgi_param  SERVER_ADDR        $server_addr;
+  fastcgi_param  SERVER_PORT        $server_port;
+  fastcgi_param  SERVER_NAME        $hostname;
+
+  # PHP only, required if PHP was built with --enable-force-cgi-redirect
+  fastcgi_param  REDIRECT_STATUS    200;
+
+  # Pantheon params
+
+  fastcgi_param PATH_INFO $fastcgi_path_info;
+  fastcgi_param PATH_TRANSLATED $document_root$fastcgi_path_info;
+
+  # Set HTTPS to the value of User-agent-HTTPS, 'on' or 'off'
+  fastcgi_param HTTPS $http_user_agent_https if_not_empty;

--- a/plugins/lando-pantheon/recipes/pantheon/wordpress.conf.tpl
+++ b/plugins/lando-pantheon/recipes/pantheon/wordpress.conf.tpl
@@ -149,7 +149,7 @@ server {
         fastcgi_intercept_errors on;
         fastcgi_pass fpm:9000;
         fastcgi_index index.php;
-        include fastcgi_params;
+        include /srv/includes/fastcgi_params;
         # Allow SimpleSamlPHP to work by settig PATH_INFO, etc
         fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
         fastcgi_param SCRIPT_FILENAME "{{LANDO_WEBROOT}}$fastcgi_script_name";
@@ -172,7 +172,7 @@ server {
         fastcgi_intercept_errors on;
         fastcgi_pass fpm:9000;
         fastcgi_index index.php;
-        include fastcgi_params;
+        include /srv/includes/fastcgi_params;
         # Allow SimpleSamlPHP to work by settig PATH_INFO, etc
         fastcgi_split_path_info ^(.+?\.php)(|/.*)$;
         fastcgi_param SCRIPT_FILENAME "{{LANDO_WEBROOT}}$fastcgi_script_name";


### PR DESCRIPTION
This is done on Pantheon and seems to be needed for the latest versions
of SimpleSaml. Researching these params for NGINX in general, it seems
these values are actually set by default:

@see https://www.nginx.com/resources/wiki/start/topics/examples/phpfcgi/

I've tried to write some func tests for this based on the example above, but I can't get it to work. @pirog I am not sure if the place I editted this is getting loaded correctly.