### PR TITLE
Fix typo in mailhog.md

### DIFF
--- a/docs/config/mailhog.md
+++ b/docs/config/mailhog.md
@@ -80,7 +80,7 @@ services:
     type: php
 ```
 
-Note that we will install the [mhsendmail](https://github.com/mailhog/mhsendmail) binary at `/usr/local/bin/mhsendmail` in each `hogfrom` service for you to use. Each of these services should also be able to access the MailHog STMP server using the `MH_SENDMAIL_SMTP_ADDR` environment variable which his set to `sendmailhog:1025` by default.
+Note that we will install the [mhsendmail](https://github.com/mailhog/mhsendmail) binary at `/usr/local/bin/mhsendmail` in each `hogfrom` service for you to use. Each of these services should also be able to access the MailHog STMP server using the `MH_SENDMAIL_SMTP_ADDR` environment variable which is set to `sendmailhog:1025` by default.
 
 ## Getting information
 


### PR DESCRIPTION
Small typo in `mailhog.md` (`his` -> `is`).