### PR TITLE
Fix create recipe link

### DIFF
--- a/docs/config/recipes.md
+++ b/docs/config/recipes.md
@@ -8,7 +8,7 @@ Recipes are Lando's highest level abstraction and they contain common combinatio
 
 ## Usage
 
-You can use the top-level `recipe` config in your [Landofile](./lando.md) to select a recipe. Note that you will need to select one of the [supported recipes](#supported-recipes) or [create your own](./../contrib-plugins.md).
+You can use the top-level `recipe` config in your [Landofile](./lando.md) to select a recipe. Note that you will need to select one of the [supported recipes](#supported-recipes) or [create your own](./../contrib/contrib-plugins.html#recipes).
 
 For example this will use the [Drupal 8](./drupal8.md) recipe.
 


### PR DESCRIPTION
The current link to creating your own recipe is out of date and 404s.

Thank you so much for contributing code to Lando! If this is your **first time** contributing to Lando we recommend you first check our [Getting Involved](https://docs.lando.dev/contrib/contributing.html) docs.

It may also be useful to check the below documentation based on what you are trying to do:

* [Adding code to Lando](https://docs.lando.dev/contrib/contrib-intro.html)
* [Updating documentation](https://docs.lando.dev/contrib/contrib-intro.html)
* [Working on DevOps](https://docs.lando.dev/contrib/contrib-intro.html)
* [Working on Lando's auxiliary services eg websites, apis, etc](https://docs.lando.dev/contrib/contrib-intro.html)
* [Writing Lando Guides](https://docs.lando.dev/contrib/guides-intro.html)
* [Writing Lando blog posts](https://docs.lando.dev/contrib/blogging-intro.html)

We will get to your PR as soon as we can but in the meantime you might want to check to make sure you have done the following. **The more boxes you can check the easier it will be for us to merge in your changes with confidence**

- [x] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/help)
- [ ] My code includes a [functional test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes a [unit test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

