### PR TITLE
Add support for Postgres 12.

### DIFF
--- a/docs/config/postgres.md
+++ b/docs/config/postgres.md
@@ -12,6 +12,7 @@ You can easily add it to your Lando app by adding an entry to the [services](./.
 
 ## Supported versions
 
+*   [12](https://hub.docker.com/r/bitnami/postgresql)
 *   [11](https://hub.docker.com/r/bitnami/postgresql)
 *   [11.1.0](https://hub.docker.com/r/bitnami/postgresql)
 *   **[10](https://hub.docker.com/r/bitnami/postgresql)** **(default)**

--- a/plugins/lando-services/services/postgres/builder.js
+++ b/plugins/lando-services/services/postgres/builder.js
@@ -10,8 +10,9 @@ module.exports = {
   name: 'postgres',
   config: {
     version: '10',
-    supported: ['11', '11.1', '11.0', '10', '10.6.0', '9.6'],
+    supported: ['12', '11', '11.1', '11.0', '10', '10.6.0', '9.6'],
     pinPairs: {
+      '12': 'bitnami/postgresql:12.2.0-debian-10-r57',
       '11': 'bitnami/postgresql:11.7.0-debian-10-r34',
       '10': 'bitnami/postgresql:10.12.0-debian-10-r36',
       '9.6': 'bitnami/postgresql:9.6.17-debian-10-r37',


### PR DESCRIPTION
Hey @pirog as promised here's the PR for postgres 12 support.

Everything seems to be running fine so it was a pretty simple update.
The only thing I'm not sure about is the pinPairs update, I couldn't work out what they're used for.
But I made an assumption and grabbed the latest tag for postgres 12 and added it as a pinPair.

I haven't updated the changelog like the PR requested as well.. I have no idea when this would get released!

