### PR TITLE
Only add PathPrefixStrip if we actually have a subdir.

### DIFF
--- a/plugins/lando-proxy/lib/utils.js
+++ b/plugins/lando-proxy/lib/utils.js
@@ -69,7 +69,7 @@ exports.parseRoutes = urls => {
     const hostRegex = parsedUrl.host.replace(new RegExp('\\*', 'g'), '{wildcard:[a-z0-9-]+}');
     labels[`traefik.${i}.frontend.rule`] = `HostRegexp:${hostRegex}`;
     labels[`traefik.${i}.port`] = parsedUrl.port;
-    if (parsedUrl.pathname) {
+    if (parsedUrl.pathname.length > 1) {
       labels[`traefik.${i}.frontend.rule`] += `;PathPrefixStrip:${parsedUrl.pathname}`;
     }
   });


### PR DESCRIPTION
parsedUrl.pathname is '/' if there is no subdir, but that should not be sent as a stripped prefix.

Fixes #2149 