### PR TITLE
cache: none gave me an error but when I removed it worked fine

### DIFF
--- a/docs/config/laravel.md
+++ b/docs/config/laravel.md
@@ -51,7 +51,6 @@ config:
   via: apache:2.4
   webroot: .
   database: mysql:5.7
-  cache: none
   xdebug: false
   config:
     database: SEE BELOW


### PR DESCRIPTION
before: Cannot read property 'type' of undefined

- [x] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/help)
- [ ] My code includes a [functional test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes a [unit test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [x] My code includes documentation updates if applicable.
- [x] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

