### PR TITLE
#2318 Updated script to assure useradd wasn't executed if web user 50…

### DIFF
--- a/experimental/plugins/lando-platformsh/scripts/psh-recreate-users.sh
+++ b/experimental/plugins/lando-platformsh/scripts/psh-recreate-users.sh
@@ -1,5 +1,5 @@
 # This script assures there is a `web` and `app` user
-# and that the `web` user is assigned the uid of 501.
+# and that the `web` user is assigned the uid of $LANDO_HOST_UID.
 #!/bin/sh
 set -e
 

--- a/experimental/plugins/lando-platformsh/scripts/psh-recreate-users.sh
+++ b/experimental/plugins/lando-platformsh/scripts/psh-recreate-users.sh
@@ -1,3 +1,5 @@
+# This script assures there is a `web` and `app` user
+# and that the `web` user is assigned the uid of 501.
 #!/bin/sh
 set -e
 
@@ -7,24 +9,58 @@ set -e
 # Set the module
 LANDO_MODULE="platformsh-webuser"
 
-# Recreate the web user so it has the uid/gid of the host user
-# @NOTE: for some reason the usual resetting we do in user-perms.sh
-# is very slow and produces weird results for
-#
-# @TODO: we need to get the appropriate guards in here so we dont have to || true things
-deluser app > /dev/null || true
-deluser web > /dev/null || true
-useradd \
-  --uid "$LANDO_HOST_UID" \
-  --user-group \
-  --home /app \
-  --non-unique \
-  --shell /bin/bash \
-  -M \
-  web > /dev/null || true
-useradd \
-  --user-group \
-  --home /mnt \
-  --shell /bin/false \
-  -M \
-  app > /dev/null || true
+APP_USERNAME=app
+WEB_USERNAME=web
+
+addWebuser() {
+    useradd \
+    --uid "$LANDO_HOST_UID" \
+    --user-group \
+    --home /app \
+    --non-unique \
+    --shell /bin/bash \
+    -M \
+    web > /dev/null || true
+}
+
+addAppUserIfNotExists() {
+  if [[ $(getent passwd $APP_USERNAME) = "" ]]; then
+        useradd \
+        --user-group \
+        --home /mnt \
+        --shell /bin/false \
+        -M \
+        app
+  fi
+}
+
+# Get the username of user with LANDO_HOST_UID
+FOUND_USERNAME=$(getent passwd $LANDO_HOST_UID | cut -d: -f1)
+
+# Check if web user has the correct UID
+if [ "$FOUND_USERNAME" = $WEB_USERNAME ]; then
+  # If so, create app user if it doesn't exist and exit
+  addAppUserIfNotExists
+  exit 0
+fi
+
+# Web user was not found or did not have the correct UID
+# Check if a different user was found for the UID
+if ! [ "$FOUND_USERNAME" = "" ]; then
+  # Delete it (This may be "app"; If so, we'll add it back later)
+  deluser $FOUND_USERNAME
+fi
+
+# Now check if there's a "web" user with a UID that is not LANDO_HOST_UID
+if id -u $WEB_USERNAME >/dev/null 2>&1; then
+  # Delete so we can add it with the proper UID
+  deluser $WEB_USERNAME
+fi
+
+# At this point there is no "web" user and no user with the LANDO_HOST_UID
+# Add the web user
+addWebuser
+
+# Last, in case app user is missing, or we deleted it because it had the LANDO_HOST_UID
+# Create the app user if it doesn't exist
+addAppUserIfNotExists


### PR DESCRIPTION
This PR contains an update of `psh-recrate-users.sh` which does not execute any add or delete user functionality if the `web` and `app` users are setup appropriately.

In the case the `web` is not uid `501`, or that uid `501` is not `web`, the user will be deleted and recreated appropriately.