### PR TITLE
Add troubleshooting instructions for unconventional deb installs.

### DIFF
--- a/docs/basics/installation.md
+++ b/docs/basics/installation.md
@@ -134,6 +134,8 @@ We set `docker-ce` as a hard dependency for our packages. This means if you have
 dpkg -i --ignore-depends=docker-ce lando-stable.deb
 ```
 
+After installing lando this way, you may need to edit the `/var/lib/dpkg/status` file and remove `docker-ce` from the lando package dependency list in order for future `apt` related commands to work. Great care should be taken while editting this file!!!.
+
 We are currently considering whether to support alternate means of installing Docker such as with [moby-engine](https://github.com/lando/lando/issues/1294)
 
 #### Arch


### PR DESCRIPTION
Address unmet dependencies error when `sudo apt upgrade` is ran.

https://serverfault.com/a/506993
https://superuser.com/a/815371