### PR TITLE
#2364 Removed close to resolve the RPC errors in container logs.

### DIFF
--- a/experimental/plugins/lando-platformsh/scripts/psh-fake-rpc.py
+++ b/experimental/plugins/lando-platformsh/scripts/psh-fake-rpc.py
@@ -6,4 +6,4 @@ RpcServer(
     "/run/shared/agent.sock",
     "foo",
     root=None,
-    root_factory=lambda c,a: c.send(json.dumps({"jsonrpc":"2.0","result":True,"id": json.loads(c.recv(1024))["id"]})) and c.close())._accepter_greenlet.get();
+    root_factory=lambda c,a: c.send(json.dumps({"jsonrpc":"2.0","result":True,"id": json.loads(c.recv(1024))["id"]})))._accepter_greenlet.get();


### PR DESCRIPTION
This PR removes `close() ` in `psh-fake-rpc.py` to resolve errors in container logs.
