### PR TITLE
Make load-keys.sh compatible with MacOS High Sierra by removing group permissions check on keys

### DIFF
--- a/plugins/lando-core/scripts/load-keys.sh
+++ b/plugins/lando-core/scripts/load-keys.sh
@@ -68,7 +68,7 @@ fi
 # Scan the following directories for keys and filter out non-private keys
 for SSH_DIR in "${SSH_DIRS[@]}"; do
   lando_info "Scanning $SSH_DIR for keys..."
-  readarray -t RAW_LIST < <(find "$SSH_DIR" -maxdepth 1 -not -name '*.pub' -not -name 'known_hosts' -user $LANDO_WEBROOT_USER -group $GROUP -type f)
+  readarray -t RAW_LIST < <(find "$SSH_DIR" -maxdepth 1 -not -name '*.pub' -not -name 'known_hosts' -user $LANDO_WEBROOT_USER -type f)
   for RAW_KEY in "${RAW_LIST[@]}"; do
     SSH_CANDIDATES+=("$RAW_KEY")
   done


### PR DESCRIPTION
We will get to your PR as soon as we can but in the meantime you might want to check to make sure you have done the following. **The more boxes you can check the easier it will be for us to merge in your changes with confidence**

- [x] My code includes the latest code from the `master` branch
- [x] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/help)
  - It doesn't seem appropriate to update `docs/help/2020-changelog.md` at this point.  If this PR is accepted, here is a suggestion: **Make load-keys.sh compatible with MacOS High Sierra by removing group permissions check on keys.**
- [ N/A ] My code includes a [functional test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ N/A ] My code includes a [unit test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ N/A ] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [x] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

----------

This small change resolves the MacOS High Sierra issue described in https://github.com/lando/lando/issues/1657#issuecomment-514937215. It does this by removing the check on the key file's group.  Under High Sierra the group check fails:

In the container `id` returns:
```
www-data@7d72e89ae306:/app$ id
uid=149902NNNN(www-data) gid=54999NNNN(www-data) groups=54999NNNN(www-data)
```
but when listing a key file the gid _appears_ not to match as the result of something strange about High Sierra:
```
www-data@7d72e89ae306:/app$ ls -ln /user/.ssh/id_rsa
-rw------- 1 149902NNNN 549 3381 Jun 16 16:18 /user/.ssh/id_rsa
```

Shout out to @dsnopek who helped debug!