### PR TITLE
#2395 Added supportedIgnore config to bypass supported version check

### DIFF
--- a/experimental/plugins/lando-platformsh/services/platformsh-elasticsearch/builder.js
+++ b/experimental/plugins/lando-platformsh/services/platformsh-elasticsearch/builder.js
@@ -7,11 +7,10 @@ const _ = require('lodash');
 module.exports = {
   name: 'platformsh-elasticsearch',
   config: {
-    version: '7.2',
-    supported: ['7.2', '7.7', '6.5', '5.4', '5.2', '2.4', '1.7', '1.4', '0.9'],
-    legacy: ['5.4', '5.2', '2.4', '1.7', '1.4', '0.9'],
     confSrc: __dirname,
+    legacy: ['5.4', '5.2', '2.4', '1.7', '1.4', '0.9'],
     port: '9200',
+    supportedIgnore: true,
   },
   parent: '_platformsh_service',
   builder: (parent, config) => class LandoPlatformsElasticsearch extends parent {

--- a/experimental/plugins/lando-platformsh/services/platformsh-mariadb/builder.js
+++ b/experimental/plugins/lando-platformsh/services/platformsh-mariadb/builder.js
@@ -7,11 +7,10 @@ const _ = require('lodash');
 module.exports = {
   name: 'platformsh-mariadb',
   config: {
-    version: '10.4',
-    supported: ['10.4', '10.3', '10.2', '10.1', '10.0', '5.5'],
-    legacy: [],
     confSrc: __dirname,
+    legacy: [],
     port: '3306',
+    supportedIgnore: true,
   },
   parent: '_platformsh_service',
   builder: (parent, config) => class LandoPlatformshMariaDB extends parent {

--- a/experimental/plugins/lando-platformsh/services/platformsh-memcached/builder.js
+++ b/experimental/plugins/lando-platformsh/services/platformsh-memcached/builder.js
@@ -7,10 +7,9 @@ const _ = require('lodash');
 module.exports = {
   name: 'platformsh-memcached',
   config: {
-    version: '1.6',
-    supported: ['1.6', '1.5', '1.4'],
     confSrc: __dirname,
     port: '11211',
+    supportedIgnore: true,
   },
   parent: '_platformsh_service',
   builder: (parent, config) => class LandoPlatformshMemcached extends parent {

--- a/experimental/plugins/lando-platformsh/services/platformsh-mongodb/builder.js
+++ b/experimental/plugins/lando-platformsh/services/platformsh-mongodb/builder.js
@@ -7,10 +7,9 @@ const _ = require('lodash');
 module.exports = {
   name: 'platformsh-mongodb',
   config: {
-    version: '3.6',
-    supported: ['3.6', '3.4', '3.2', '3.0'],
     confSrc: __dirname,
     port: '27017',
+    supportedIgnore: true,
   },
   parent: '_platformsh_service',
   builder: (parent, config) => class LandoPlatformsMongoDB extends parent {

--- a/experimental/plugins/lando-platformsh/services/platformsh-php/builder.js
+++ b/experimental/plugins/lando-platformsh/services/platformsh-php/builder.js
@@ -7,10 +7,9 @@ const _ = require('lodash');
 module.exports = {
   name: 'platformsh-php',
   config: {
-    version: '7.4',
-    supported: ['7.4', '7.3', '7.2', '7.1', '7.0', '5.6', '5.5', '5.4'],
-    legacy: ['7.1', '7.0', '5.5', '5.4', '5.3'],
     confSrc: __dirname,
+    legacy: ['7.1', '7.0', '5.5', '5.4', '5.3'],
+    supportedIgnore: true,
     volumes: ['/usr/local/bin'],
   },
   parent: '_platformsh_appserver',

--- a/experimental/plugins/lando-platformsh/services/platformsh-postgresql/builder.js
+++ b/experimental/plugins/lando-platformsh/services/platformsh-postgresql/builder.js
@@ -7,11 +7,10 @@ const _ = require('lodash');
 module.exports = {
   name: 'platformsh-postgresql',
   config: {
-    version: '11',
-    supported: ['12', '11', '10', '9.6', '9.3'],
-    legacy: ['9.3'],
     confSrc: __dirname,
+    legacy: ['9.3'],
     port: '5432',
+    supportedIgnore: true,
   },
   parent: '_platformsh_service',
   builder: (parent, config) => class LandoPlatformshPostgres extends parent {

--- a/experimental/plugins/lando-platformsh/services/platformsh-redis/builder.js
+++ b/experimental/plugins/lando-platformsh/services/platformsh-redis/builder.js
@@ -7,11 +7,10 @@ const _ = require('lodash');
 module.exports = {
   name: 'platformsh-redis',
   config: {
-    version: '5.0',
-    supported: ['5.0', '4.0', '3.2', '3.0', '2.8'],
-    legacy: ['3.0', '2.8'],
     confSrc: __dirname,
+    legacy: ['3.0', '2.8'],
     port: '6379',
+    supportedIgnore: true,
   },
   parent: '_platformsh_service',
   builder: (parent, config) => class LandoPlatformshRedis extends parent {

--- a/experimental/plugins/lando-platformsh/services/platformsh-solr/builder.js
+++ b/experimental/plugins/lando-platformsh/services/platformsh-solr/builder.js
@@ -7,10 +7,9 @@ const _ = require('lodash');
 module.exports = {
   name: 'platformsh-solr',
   config: {
-    version: '8.4',
-    supported: ['8.4', '8.0', '7.7', '7.6', '6.6', '6.3', '4.1', '3.6'],
     confSrc: __dirname,
     port: '8080',
+    supportedIgnore: true,
   },
   parent: '_platformsh_service',
   builder: (parent, config) => class LandoPlatformshSolr extends parent {

--- a/plugins/lando-core/compose/lando/builder.js
+++ b/plugins/lando-core/compose/lando/builder.js
@@ -48,6 +48,7 @@ module.exports = {
         ssl = false,
         sslExpose = true,
         supported = ['custom'],
+        supportedIgnore = false,
         root = '',
         webroot = '/app',
       } = {},
@@ -58,7 +59,7 @@ module.exports = {
 
       // If this version is not supported throw an error
       // @TODO: get this someplace else for unit tezting
-      if (!_.includes(supported, version)) {
+      if (!supportedIgnore && !_.includes(supported, version)) {
         if (!patchesSupported || !_.includes(utils.stripWild(supported), utils.stripPatch(version))) {
           throw Error(`${type} version ${version} is not supported`);
         }


### PR DESCRIPTION
This PR adds support for the `supportedIgnore` service config which bypasses the version validation against the `supported` array.