### PR TITLE
Update Drupal 8 recipe to use PHP 7.3

### DIFF
--- a/plugins/lando-recipes/recipes/drupal8/builder.js
+++ b/plugins/lando-recipes/recipes/drupal8/builder.js
@@ -16,7 +16,7 @@ module.exports = {
   config: {
     confSrc: __dirname,
     defaultFiles: {},
-    php: '7.2',
+    php: '7.3',
     drupal: true,
   },
   builder: (parent, config) => class LandoDrupal8 extends parent {


### PR DESCRIPTION
PHP 7.2 is no longer recommended for Drupal 8. See https://www.drupal.org/docs/system-requirements/php-requirements

- [x ] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/help)
- [ ] My code includes a [functional test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes a [unit test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

