### PR TITLE
Fixes documentation links in the Alliance section

### DIFF
--- a/docs/contrib/allianceroles.md
+++ b/docs/contrib/allianceroles.md
@@ -8,7 +8,7 @@ metaTitle: Read more on how to contribute | Lando
 Now that you are set up for contributing, in general, proceed to the docs for the specific roles you are interested in. A rough idea of what you will learn about in each section is shown below:
 
 ::: half
-#### [EVANGELIST](evangelist-intro)
+#### [EVANGELIST](evangelist-intro.md)
 * Lando talking points
 * Lando slide deck templates
 * Posting your event to [events.lando.dev](https://events.lando.dev)
@@ -16,7 +16,7 @@ Now that you are set up for contributing, in general, proceed to the docs for th
 :::
 
 ::: half
-#### [CONTRIBUTOR](contrib-intro)
+#### [CONTRIBUTOR](contrib-intro.md)
 * Contributing code to Lando
 * Working on Lando web properties
 * Writing Lando tests
@@ -25,20 +25,20 @@ Now that you are set up for contributing, in general, proceed to the docs for th
 :::
 
 ::: half
-#### [GUIDER](guides-intro)
+#### [GUIDER](guides-intro.md)
 * Writing Lando guides
 * Testing guide content with Leia
 * Marketing guide content
 :::
 
 ::: half
-#### [BLOGGER](blogging-intro)
+#### [BLOGGER](blogging-intro.md)
 * Writing blog content
 * Marketing blog content
 :::
 
 ::: half
-#### [ADMINISTRATOR](admin-intro)
+#### [ADMINISTRATOR](admin-intro.md)
 * Administering the Lando Alliance
 * Administering Lando sponsors
 * Running Lando social media
@@ -46,13 +46,13 @@ Now that you are set up for contributing, in general, proceed to the docs for th
 :::
 
 ::: half
-#### [UPSELLER](upseller-intro)
+#### [UPSELLER](upseller-intro.md)
 * Talking points for your boss
 * Lando services and support
 :::
 
 ::: half
-#### [SPONSOR](sponsor-intro)
+#### [SPONSOR](sponsor-intro.md)
 * Frequently asked questions
 * Managing your sponsorship
 :::

--- a/docs/contrib/contrib-intro.md
+++ b/docs/contrib/contrib-intro.md
@@ -26,7 +26,7 @@ This section is designed for people who want to contribute `code things` to Land
 
 ## What do I need to get started?
 
-You will need to go through all the steps in our [Getting Involved](contributing) section if you have not done so already. This will get you rolling for contribution. All the steps from the aforementioned section for completeness are shown below:
+You will need to go through all the steps in our [Getting Involved](contributing.md) section if you have not done so already. This will get you rolling for contribution. All the steps from the aforementioned section for completeness are shown below:
 
 1. [Join the alliance](./join.md) as a contributor
 2. [Join the comms](./comms.md)


### PR DESCRIPTION
- [x] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/help)
- [ ] My code includes a [functional test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes a [unit test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [x] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

While browsing the docs, I noticed that a few links are broken. Let's get them working and get more allies! :)