### PR TITLE
Add varnish support to Lagoon plugin

### DIFF
--- a/experimental/plugins/lando-lagoon/README.md
+++ b/experimental/plugins/lando-lagoon/README.md
@@ -69,7 +69,7 @@ The tentative roadmap for acheiving the above is
 * An alpha quality release that covers sections 1. and 2. in the overview.
 * This release is scheduled to be an "internal alpha" but it may be ok to cast a wider net as long as the alpha part is understood.
 * A user should be able to `lando init` a cloned down `lagoon` Drupal 8/9 git repo that is properly configured for use with Lando and get it running
-* Popular Drupal services like `mariadb`, `mysql`, `memcached`, `redis`, `solr`, `postgresql` and `elasticsearch` are expected to work
+* Popular Drupal services like `mariadb`, `mysql`, `memcached`, `redis`, `solr`, `postgresql` and `varnish` are expected to work
 
 These are all expected to be delivered at `alpha` level quality eg the 80/20 rule for use case coverage is probably a good quality threshold.
 
@@ -94,7 +94,7 @@ This plugin follows the same structure as any [Lando plugin](https://docs.lando.
 |-- lib             Utilities and helpers, things that can easily be unit tested
 |-- recipes
     |-- lagoon      The files to define the `lagoon` recipe and its `init` command
-|-- services        Defines each platform.sh service eg `redis` or `php`
+|-- services        Defines each Lagoon service eg `solr` or `php`
 |-- test            Unit tests
 |-- types           Defines the type/parent each above service can be
 |-- app.js          Modifications to the app runtime

--- a/experimental/plugins/lando-lagoon/lib/services.js
+++ b/experimental/plugins/lando-lagoon/lib/services.js
@@ -22,9 +22,12 @@ const getLandoServiceType = type => {
     case 'php-cli-drupal': return 'lagoon-php-cli';
     case 'php-fpm': return 'lagoon-php';
     case 'redis': return 'lagoon-redis';
+    case 'solr': return 'lagoon-solr';    
     case 'solr-drupal': return 'lagoon-solr';
     case 'postgres': return 'lagoon-postgres';
     case 'postgres-drupal': return 'lagoon-postgres';
+    case 'varnish': return 'lagoon-varnish';
+    case 'varnish-drupal': return 'lagoon-varnish';
     default: return false;
   };
 };

--- a/experimental/plugins/lando-lagoon/services/lagoon-varnish/builder.js
+++ b/experimental/plugins/lando-lagoon/services/lagoon-varnish/builder.js
@@ -1,0 +1,49 @@
+'use strict';
+
+// Modules
+const _ = require('lodash');
+
+// Builder
+module.exports = {
+  name: 'lagoon-varnish',
+  config: {
+    version: 'custom',
+    backends: ['nginx'],
+    confSrc: __dirname,
+    command: '/sbin/tini -- /lagoon/entrypoints.sh /varnish-start.sh',
+    moreHttpPorts: ['8080'],
+    port: '8080',
+  },
+  parent: '_lagoon',
+  builder: (parent, config) => class LandoLagoonVarnish extends parent {
+    constructor(id, options = {}, factory) {
+      options = _.merge({}, config, options);
+
+      // Set the meUser
+      options.meUser = 'varnish';
+      // Ensure the non-root backup perm sweep runs
+      // NOTE: we guard against cases where the UID is the same as the bitnami non-root user
+      // because this messes things up on circle ci and presumably elsewhere and _should_ be unncessary
+      if (_.get(options, '_app._config.uid', '1000') !== '1001') options._app.nonRoot.push(options.name);
+
+      const varnish = {
+        command: options.command,
+        ports: [options.port],
+        depends_on: options.backends,
+      };
+      // Add some lando info
+      options.info = _.merge({}, options.info, {
+        internal_connection: {
+          host: options.name,
+          port: options.port,
+        },
+        external_connection: {
+          host: options._app._config.bindAddress,
+          port: _.get(options, 'portforward', 'not forwarded'),
+        },
+      });
+      // Send it downstream
+      super(id, options, {services: _.set({}, options.name, varnish)});
+    };
+  },
+};


### PR DESCRIPTION
ok - after thinking we can skip Varnish for local development - I then realised that removing it *may* not help some people's debugging efforts!

Where this is up to:

A project configured (as per https://lagoon.readthedocs.io/en/latest/using_lagoon/drupal/services/varnish/) can:

* Start their stack, and get the varnish container running, and talking to the nginx backend
* Access the varnish container via it's localhost:32xxx port and see the HIT/MISS come through correctly

Where this is lacking is with some of the finesse - for example, the main `*.lndo.site` route continues to go through the nginx container - maybe this is desirable, and then have varnish on a separate route - it's just a deviation from what pygmy used to do.

I'd certainly appreciate another pair of eyes on this to see if I've missed anything obvious.

I'll have to add a branch to drupal-example-simple with varnish enabled - but the current amazeeio/drupal-example also works OOTB if the `lando.type` tags are added.

- [x] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/help)
- [ ] My code includes a [functional test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes a [unit test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [x] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

