### PR TITLE
Adds Ubuntu Firefox specific steps to Trusting the CA documentation

### DIFF
--- a/docs/config/security.md
+++ b/docs/config/security.md
@@ -111,6 +111,10 @@ sudo rm -f /usr/local/share/ca-certificates/lndo.site.crt
 sudo update-ca-certificates --fresh
 ```
 
+### Ubuntu with Firefox
+
+Import the `~/.lando/certs/lndo.site.pem` CA certificate in Firefox by going to `about:preferences#privacy` > `View Certificates` > `Authorities` > `Import`, enabling **Trust this CA to identify websites.**.
+
 ### Arch
 
 ```bash


### PR DESCRIPTION
The suggested Debian steps, as well as the "warning Firefox" steps don't seem to work for the Ubuntu + Firefox combination. Issue discussed in #2047.

- [x] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/help)
- [ ] My code includes a [functional test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes a [unit test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [x] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

