### PR TITLE
Show app name in Destroy prompt

### DIFF
--- a/plugins/lando-core/tasks/destroy.js
+++ b/plugins/lando-core/tasks/destroy.js
@@ -5,7 +5,7 @@ module.exports = lando => {
     command: 'destroy',
     describe: 'Destroys your app',
     options: {
-      yes: lando.cli.confirm('Are you sure you want to DESTROY?'),
+      yes: lando.cli.confirm('Are you sure you want to DESTROY %s?', app.name),
     },
     run: options => {
       // Stop rebuild if user decides its a nogo


### PR DESCRIPTION
**Problem**
Sometimes you copy `.lando.yml` files from project to project, and forget to update the `name` parameter, which could then overwrite as well as remove the wrong project, when you run `lando destroy`.

**Solution**
It would be great if the app name was shown as part of the Warning message after running `lando destroy`, since this could help catch such instances, before it was run.

This might not work at all, since I can't test it locally ... I tried to find the Lando files with `whereis lando`, which pointed me to `lando: /usr/local/bin/lando /usr/share/lando` (Ubuntu 18.04) but neither place, seemed to contain the `destroy.js` file ... if anyone can point me to the correct folder, I'd be thankful. Possibly `const app = lando.getApp(options._app.root);` needs to be added, for `app.name` to be available?

- [x] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/help)
- [ ] My code includes a [functional test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes a [unit test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

