### PR TITLE
#2529: Use destination parameter if needed when doing platform build

### DIFF
--- a/docs/help/2020-changelog.md
+++ b/docs/help/2020-changelog.md
@@ -1,5 +1,14 @@
 # 2020
 
+## v3.0.11 - In development
+
+Lando is **free** and **open source** software that relies on contributions from developers like you! If you like Lando then help us spend more time making, updating and supporting it by [contributing](https://github.com/sponsors/lando).
+
+* Fixed bug causing the `proxy` to report `404` when using more than one `platformsh` app [#2507](https://github.com/lando/lando/pull/2507)
+* Fixed bug causing `platformsh` recipe build to fail when webroot doesn't exist [#2529](https://github.com/lando/lando/pull/2529)
+
+[What does pre-release mean?](https://docs.lando.dev/config/releases.html)
+
 ## v3.0.10 - [July 27, 2020](https://github.com/lando/lando/releases/tag/v3.0.10)
 
 Lando is **free** and **open source** software that relies on contributions from developers like you! If you like Lando then help us spend more time making, updating and supporting it by [contributing](https://github.com/sponsors/lando).

--- a/integrations/lando-platformsh/app.js
+++ b/integrations/lando-platformsh/app.js
@@ -76,7 +76,6 @@ module.exports = (app, lando) => {
       app.log.silly('platformsh routes are', app.platformsh.routes);
 
       // Add the parsed applications config
-      // @TODO: the parsing here should happen
       app.platformsh.applications = pshconf.parseApps(platformConfig, app.root);
       app.log.verbose('parsed platformsh applications');
       app.log.silly('platformsh applications are', app.platformsh.applications);

--- a/integrations/lando-platformsh/lib/config.js
+++ b/integrations/lando-platformsh/lib/config.js
@@ -48,6 +48,17 @@ const parseServiceRelationships = ({relationships = {}}) => {
 };
 
 /*
+ * Helper to replace defaualt
+ */
+const replaceDefault = (data, replacer) => {
+  if (_.isObject(data)) {
+    return JSON.parse(JSON.stringify(data).replace(/{default}/g, replacer));
+  } else {
+    return data.replace(/{default}/g, replacer);
+  }
+};
+
+/*
  * Helper to set primary route if needed
  */
 const setPrimaryRoute = (routes = []) => {
@@ -60,7 +71,6 @@ const setPrimaryRoute = (routes = []) => {
   // Return
   return routes;
 };
-
 
 /*
  * Helper to find closest app
@@ -149,10 +159,22 @@ exports.parseRelationships = (apps, open = {}) => _(apps)
  * Helper to parse the platformsh routes file eg replace DEFAULT in the routes.yml
  */
 exports.parseRoutes = (routes, domain) => _(routes)
-  .map((config, url) => ([url, _.merge({primary: false}, config)]))
+  // Add implicit data and defaults
+  .map((config, url) => ([url, _.merge({primary: false, attributes: {}, id: null, original_url: url}, config)]))
+  // Replace URL defaults
+  .map(route => ([replaceDefault(route[0], domain), route[1]]))
+  // Replace config defaults
+  .map(route => ([route[0], _.merge(route[1], replaceDefault(_.omit(route[1], ['original_url']), domain))]))
+  // Strip upstream if needed
+  .map(route => {
+    if (route[1].upstream) route[1].upstream = _.first(route[1].upstream.split(':'));
+    return [route[0], route[1]];
+  })
+  // Back to object
   .fromPairs()
-  .thru(routes => JSON.parse(JSON.stringify(routes).replace(/{default}/g, domain)))
+  // Set the primary route
   .thru(routes => setPrimaryRoute(routes))
+  // Return
   .value();
 
 /*

--- a/integrations/lando-platformsh/lib/config.js
+++ b/integrations/lando-platformsh/lib/config.js
@@ -5,6 +5,7 @@ const _ = require('lodash');
 const fs = require('fs');
 const path = require('path');
 const PlatformYaml = require('./yaml');
+const utils = require('./utils');
 
 /*
  * Helper to get appMount
@@ -119,6 +120,7 @@ exports.parseApps = ({applications, applicationFiles}, appRoot) => _(application
     // @NOTE: probably not relevant until we officially support multiapp?
     hostname: `${app.name}.0`,
     sourceDir: _.has(app, 'source.root') ? path.join('/app', app.source.root) : '/app',
+    webroot: utils.getDocRoot(app),
   }))
   // And the webPrefix
   .map(app => _.merge({}, app, {

--- a/integrations/lando-platformsh/lib/run.js
+++ b/integrations/lando-platformsh/lib/run.js
@@ -4,6 +4,7 @@
 const _ = require('lodash');
 const overrides = require('./overrides');
 const path = require('path');
+const utils = require('./utils');
 
 // Constants
 const applicationConfigDefaults = {
@@ -36,16 +37,6 @@ const applicationConfigDefaults = {
 const encode = data => {
   if (_.isObject(data)) data = JSON.stringify(data);
   return Buffer.from(data).toString('base64');
-};
-
-/*
- * Helper to get the applications doc root
- */
-const getDocRoot = appConfig => {
-  if (_.has(appConfig, 'web.locations./.root')) {
-    return `/app/${appConfig.web.locations['/'].root}`;
-  }
-  return '/app';
 };
 
 /*
@@ -131,7 +122,7 @@ const getApplicationsConfig = (apps, config) => _(apps)
  * which is special and needs to be handled separately
  */
 const getApplicationEnvironment = (appConfig, config) => _.merge({}, getEnvironmentVariables(appConfig), {
-  PLATFORM_DOCUMENT_ROOT: getDocRoot(appConfig),
+  PLATFORM_DOCUMENT_ROOT: utils.getDocRoot(appConfig),
   PLATFORM_APPLICATION: encode(appConfig),
   // @NOTE: PLATFORM_APP_DIR is normally set to /app but this is problematic locally
   // eg on Drupal this puts the /tmp and /private at /app/tmp and /app/private and

--- a/integrations/lando-platformsh/lib/utils.js
+++ b/integrations/lando-platformsh/lib/utils.js
@@ -16,6 +16,16 @@ exports.getApplicationServices = (services = []) => _(services)
   .value();
 
 /*
+ * Helper to get the applications doc root
+ */
+exports.getDocRoot = appConfig => {
+  if (_.has(appConfig, 'web.locations./.root')) {
+    return `/app/${appConfig.web.locations['/'].root}`;
+  }
+  return '/app';
+};
+
+/*
  * Helper to filter out services from application containers
  */
 exports.getNonApplicationServices = (services = []) => _(services)

--- a/integrations/lando-platformsh/scripts/psh-build.sh
+++ b/integrations/lando-platformsh/scripts/psh-build.sh
@@ -31,5 +31,14 @@ fi
 # Make sure platform things are sourced for this script
 . "$HOME/.bashrc"
 
-# Attempting to run build
-platform local:build $PLATFORM_APPLICATION_NAME
+# Run build
+# NOTE: if the build destination does not already exist we assume
+# it is created as part of the build and therefore we need to make sure
+# it is accessible from the same directory as specificed in web.locations
+if [ ! -d "$LANDO_BUILD_DESTINATION" ] || [ -L "$LANDO_BUILD_DESTINATION" ]; then
+  platform local:build $PLATFORM_APPLICATION_NAME --destination $LANDO_BUILD_DESTINATION
+
+# Otherwise its safe to use the default destination
+else
+  platform local:build $PLATFORM_APPLICATION_NAME
+fi

--- a/integrations/lando-platformsh/types/platformsh-appserver/builder.js
+++ b/integrations/lando-platformsh/types/platformsh-appserver/builder.js
@@ -56,6 +56,7 @@ module.exports = {
           LANDO_SOURCE_DIR: options.platformsh.sourceDir,
           LANDO_WEBROOT_USER: 'web',
           LANDO_WEBROOT_GROUP: 'web',
+          LANDO_BUILD_DESTINATION: _.get(options, 'platformsh.webroot'),
           PATH: LANDO_PATH.join(':'),
           PLATFORMSH_CLI_HOME: '/var/www',
           PLATFORMSH_CLI_TOKEN: _.get(options, '_app.meta.token'),

--- a/integrations/lando-platformsh/types/platformsh-appserver/builder.js
+++ b/integrations/lando-platformsh/types/platformsh-appserver/builder.js
@@ -56,7 +56,7 @@ module.exports = {
           LANDO_SOURCE_DIR: options.platformsh.sourceDir,
           LANDO_WEBROOT_USER: 'web',
           LANDO_WEBROOT_GROUP: 'web',
-          LANDO_BUILD_DESTINATION: _.get(options, 'platformsh.webroot'),
+          LANDO_BUILD_DESTINATION: _.get(options, 'platformsh.webroot', '/app'),
           PATH: LANDO_PATH.join(':'),
           PLATFORMSH_CLI_HOME: '/var/www',
           PLATFORMSH_CLI_TOKEN: _.get(options, '_app.meta.token'),

--- a/plugins/lando-proxy/lib/utils.js
+++ b/plugins/lando-proxy/lib/utils.js
@@ -117,8 +117,12 @@ exports.parseRoutes = (service, urls = [], sslReady, labels = {}) => {
     rule.middlewares.push({name: 'lando', key: 'headers.customrequestheaders.X-Lando', value: 'on'});
     // Add in any path stripping middleware we need it
     if (rule.pathname.length > 1) {
-      rule.middlewares.push({name: `${rule.id}-stripprefix`, key: 'stripprefix.prefixes', value: rule.pathname});
+      rule.middlewares.push({name: 'stripprefix', key: 'stripprefix.prefixes', value: rule.pathname});
     };
+    // Ensure we prefix all middleware with the ruleid
+    rule.middlewares = _(rule.middlewares)
+      .map(middleware => _.merge({}, middleware, {name: `${rule.id}-${middleware.name}`}))
+      .value();
 
     // Set up all the middlewares
     _.forEach(rule.middlewares, m => {


### PR DESCRIPTION
@mikemilano the check for this ended up being a lot easier than we had originally thought. We didnt need to check for the entrypoint just whether the webroot existed or not. 