### PR TITLE
Issue #2504: Skip permissions hardening by default on Pantheon apps

### DIFF
--- a/docs/help/2020-changelog.md
+++ b/docs/help/2020-changelog.md
@@ -6,6 +6,7 @@ Lando is **free** and **open source** software that relies on contributions from
 
 * Fixed bug causing `db-import` wipe to fail on `views` [#2516](https://github.com/lando/lando/pull/2516)
 * Fixed bug causing `db-import` wipe to fail on table names with hypens [#2478](https://github.com/lando/lando/pull/2478)
+* Default `skip_permission_hardening` to true on Pantheon Drupal sites [#2504](https://github.com/lando/lando/pull/2504)
 
 [What does pre-release mean?](https://docs.lando.dev/config/releases.html)
 

--- a/examples/pantheon-drupal8/README.md
+++ b/examples/pantheon-drupal8/README.md
@@ -103,6 +103,9 @@ lando push --code dev --database none --files none --message "Testing commit $(g
 cd drupal8
 lando pull --code test --database none --files none
 lando pull --code live --database none --files none
+
+# Should automatically skip permission hardening
+lando drush php-eval "print \Drupal::service('settings')->get('skip_permissions_hardening');" | grep 1
 ```
 
 Destroy tests

--- a/examples/pantheon-drupal8/README.md
+++ b/examples/pantheon-drupal8/README.md
@@ -105,7 +105,8 @@ lando pull --code test --database none --files none
 lando pull --code live --database none --files none
 
 # Should automatically skip permission hardening
-lando drush php-eval "print \Drupal::service('settings')->get('skip_permissions_hardening');" | grep 1
+cd drupal8
+lando drush php-eval "print \\Drupal::service(\'settings\')->get(\'skip_permissions_hardening\');" | grep 1
 ```
 
 Destroy tests

--- a/integrations/lando-pantheon/lib/utils.js
+++ b/integrations/lando-pantheon/lib/utils.js
@@ -106,6 +106,9 @@ const getPantheonSettings = options => ({
   },
   drupal_hash_salt: getHash(JSON.stringify(pantheonDatabases)),
   config_directory_name: 'config',
+  settings: {
+    skip_permissions_hardening: 1,
+  },
 });
 
 /*


### PR DESCRIPTION
I had some weird issues with running Drush on Drupal 8 with the default Pantheon settings.php files, but I managed to get it working and can confirm this works:
![image](https://user-images.githubusercontent.com/3948808/89320165-22090b80-d64f-11ea-8c53-1359a8eb7166.png)