### PR TITLE
update cookie stripping

### DIFF
--- a/integrations/lando-pantheon/recipes/pantheon/pantheon.vcl
+++ b/integrations/lando-pantheon/recipes/pantheon/pantheon.vcl
@@ -79,7 +79,7 @@ sub vcl_recv {
   # is so that developers always have fresh content while editing files.
   #
   # This list of file extensions is also in vcl_backend_response(), keep them in sync.
-  if (req.url ~ "(i?)\/(?!\?)[\w\-\=\&]+\.(png|gif|jpeg|jpg|ico|bmp|tif|tiff|webp|swf|css|js|woff|woff2|svg|ttf|otf|eot)($|\?)") {
+  if (req.url ~ "(i?)\/(?!\?)[\w\-\&~\.]+\.(png|gif|jpeg|jpg|ico|bmp|tif|tiff|webp|swf|css|js|woff|woff2|svg|ttf|otf|eot)($|\?)") {
     unset req.http.Cookie;
   }
 
@@ -250,7 +250,7 @@ sub vcl_pipe {
 sub vcl_backend_response {
   # Don't allow static files to set cookies. This list of file extensions is also
   # in vcl_recv(), keep them in sync.
-  if (bereq.url ~ "(i?)\/(?!\?)[\w\-\=\&]+\.(png|gif|jpeg|jpg|ico|bmp|tif|tiff|webp|swf|css|js|woff|woff2|svg|ttf|otf|eot)($|\?)") {
+  if (bereq.url ~ "(i?)\/(?!\?)[\w\-\&~\.]+\.(png|gif|jpeg|jpg|ico|bmp|tif|tiff|webp|swf|css|js|woff|woff2|svg|ttf|otf|eot)($|\?)") {
     unset beresp.http.set-cookie;
   }
 

--- a/integrations/lando-pantheon/recipes/pantheon/pantheon.vcl
+++ b/integrations/lando-pantheon/recipes/pantheon/pantheon.vcl
@@ -79,7 +79,9 @@ sub vcl_recv {
   # is so that developers always have fresh content while editing files.
   #
   # This list of file extensions is also in vcl_backend_response(), keep them in sync.
-  if (req.url ~ "(i?)\/(?!\?)[\w\-\&~\.]+\.(png|gif|jpeg|jpg|ico|bmp|tif|tiff|webp|swf|css|js|woff|woff2|svg|ttf|otf|eot)($|\?)") {
+  set req.http.url_no_qs = regsub(req.url, "\?.*$", "");
+  if (req.http.url_no_qs ~ "(?i)\.(png|gif|jpeg|jpg|ico|bmp|tif|tiff|webp|swf|css|js|woff|woff2|svg|ttf|otf|eot)$") {
+    set req.http.x-pantheon-removed-cookie = req.http.Cookie;
     unset req.http.Cookie;
   }
 
@@ -250,7 +252,10 @@ sub vcl_pipe {
 sub vcl_backend_response {
   # Don't allow static files to set cookies. This list of file extensions is also
   # in vcl_recv(), keep them in sync.
-  if (bereq.url ~ "(i?)\/(?!\?)[\w\-\&~\.]+\.(png|gif|jpeg|jpg|ico|bmp|tif|tiff|webp|swf|css|js|woff|woff2|svg|ttf|otf|eot)($|\?)") {
+
+  set bereq.http.url_no_qs = regsub(req.url, "\?.*$", "");
+  if (bereq.http.url_no_qs ~ "(?i)\.(png|gif|jpeg|jpg|ico|bmp|tif|tiff|webp|swf|css|js|woff|woff2|svg|ttf|otf|eot)$") {
+    set beresp.http.x-pantheon-removed-set-cookie = beresp.http.set-cookie;
     unset beresp.http.set-cookie;
   }
 

--- a/integrations/lando-pantheon/recipes/pantheon/pantheon.vcl
+++ b/integrations/lando-pantheon/recipes/pantheon/pantheon.vcl
@@ -79,7 +79,7 @@ sub vcl_recv {
   # is so that developers always have fresh content while editing files.
   #
   # This list of file extensions is also in vcl_backend_response(), keep them in sync.
-  if (req.url ~ "(?i)\.(png|gif|jpeg|jpg|ico|bmp|tif|tiff|webp|swf|css|js)($|\?)") {
+  if (req.url ~ "(i?)\/(?!\?)[\w\-\=\&]+\.(png|gif|jpeg|jpg|ico|bmp|tif|tiff|webp|swf|css|js|woff|woff2|svg|ttf|otf|eot)($|\?)") {
     unset req.http.Cookie;
   }
 
@@ -250,7 +250,7 @@ sub vcl_pipe {
 sub vcl_backend_response {
   # Don't allow static files to set cookies. This list of file extensions is also
   # in vcl_recv(), keep them in sync.
-  if (bereq.url ~ "(?i)\.(png|gif|jpeg|jpg|ico|bmp|tif|tiff|webp|swf|css|js)($|\?)") {
+  if (bereq.url ~ "(i?)\/(?!\?)[\w\-\=\&]+\.(png|gif|jpeg|jpg|ico|bmp|tif|tiff|webp|swf|css|js|woff|woff2|svg|ttf|otf|eot)($|\?)") {
     unset beresp.http.set-cookie;
   }
 


### PR DESCRIPTION
change cookie filtering to only operate against the path, and bring extensions inline with Pantheon's current config

fixes #2566 