### PR TITLE
#2439: Add POSIX "--" option processing functionality to tooling

### DIFF
--- a/docs/config/tooling.md
+++ b/docs/config/tooling.md
@@ -236,6 +236,34 @@ lando word
 lando word --word=fox
 ```
 
+## Option processing
+
+It is possible to disable Lando option processing for tooling by passing `--` immediately after `lando`. This is
+particularly useful when lando arguments like `-v` and `--verbose` need to be passed directly to the relevant tooling
+rather than `lando`.
+
+Using the following tooling for example:
+
+```yaml
+tooling:
+  drush:
+    cmd: "/app/vendor/bin/drush --root=/app/web"
+```
+
+```bash
+# This will enable verbose mode in just the drush tooling rather than lando, then
+# execute '/app/vendor/bin/drush --root=/app/web status -vvv' internally.
+lando -- drush status -vvv
+
+# This will enable verbose mode in both drush and lando, then
+# execute '/app/vendor/bin/drush --root=/app/web status -vvv' internally.
+lando drush status -vvv
+
+# This will enable verbose mode in both drush and lando and
+# execute '/app/vendor/bin/drush --root=/app/web -vvv -- status' internally.
+lando drush -vvv -- status
+```
+
 ## Overriding
 
 You can override tooling provided by Lando recipes or upstream Landofiles by redefining the tooling command in your Landofile.

--- a/docs/help/2020-changelog.md
+++ b/docs/help/2020-changelog.md
@@ -8,6 +8,7 @@ Lando is **free** and **open source** software that relies on contributions from
 * Fixed bug causing `db-import` wipe to fail on table names with hypens [#2478](https://github.com/lando/lando/pull/2478)
 * Fixed bug causing `lando pull` to not correctly exclude `cache` data for `pantheon` sites
 * Set `skip_permission_hardening` to `true` by default on Pantheon Drupal sites [#2504](https://github.com/lando/lando/pull/2504)
+* Improved [POSIX compatibility](https://unix.stackexchange.com/a/570733) adding the ability to skip Lando option processing in tooling through the use of `--` [#2439](https://github.com/lando/lando/issues/2439)
 
 [What does pre-release mean?](https://docs.lando.dev/config/releases.html)
 

--- a/examples/tooling/.lando.yml
+++ b/examples/tooling/.lando.yml
@@ -55,6 +55,17 @@ tooling:
           message: What is the word?
           default: bird
           weight: 600
+  tooling-script:
+    service: web
+    cmd: /app/tooling-script.sh
+    level: app
+    options:
+      word:
+        passthrough: true
+        alias:
+          - w
+        default: bird
+        describe: Print what the word is
   dynamic:
     cmd: env
     service: :service

--- a/examples/tooling/README.md
+++ b/examples/tooling/README.md
@@ -69,6 +69,13 @@ lando cmdsub | grep /app/README.md
 
 # Should be able to run bash oneliners
 lando oneliner | grep HOLLA
+
+# Should be able to handle option processing properly.
+lando tooling-script --word=dog --verbose arg1 arg2 | grep "loading app lando-tooling"
+lando -- tooling-script --word=dog --verbose arg1 arg2 | grep "loading app lando-tooling" || echo $? | grep 1
+lando tooling-script --word=dog arg1 arg2 | grep "WORD=dog args=2: arg1 arg2"
+lando tooling-script -- --word=dog arg1 arg2 | grep "WORD=bird args=3: --word=dog arg1 arg2"
+lando -- tooling-script --word=dog -- arg1 -- arg3 | grep "WORD=dog args=3: arg1 -- arg3"
 ```
 
 Destroy tests

--- a/examples/tooling/tooling-script.sh
+++ b/examples/tooling/tooling-script.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Set default opts
+WORD="bird"
+VERBOSE=0
+
+# The original command passed to the tooling script.
+ORIGINAL_ARGS="$@"
+
+# PARSE THE ARGZZ
+# TODO: compress the mostly duplicate code below?
+POSITIONAL=""
+while (( "$#" )); do
+  case "$1" in
+    -w|--word|--word=*)
+      if [ "${1##--word=}" != "$1" ]; then
+        WORD="${1##--word=}"
+        shift
+      else
+        WORD=$2
+        shift 2
+      fi
+      ;;
+    -v|-vv|-vvv|-vvvv|--verbose)
+      echo "Running tooling script in verbose mode" >&2
+      VERBOSE=1
+      shift
+      ;;
+    --)
+      shift
+      POSITIONAL="$POSITIONAL $@"
+      break
+      ;;
+    -*|--*=)
+      echo "Error: Unsupported flag $1" >&2
+      exit 1
+      ;;
+    *)
+      POSITIONAL="$POSITIONAL $1"
+      shift
+      ;;
+  esac
+done
+
+# restore positional parameters
+eval set -- "$POSITIONAL"
+
+# Demonstrate option processing by printing the word and amount of positional arguments.
+echo -n "WORD=$WORD args=$#"
+
+# Print the remaining positional arguments.
+if [ $# -gt 0 ]; then
+  echo ": $@"
+fi
+
+if [ $VERBOSE = 1 ]; then
+  echo "original tooling args: $ORIGINAL_ARGS"
+fi

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -242,7 +242,7 @@ module.exports = class Cli {
     }
 
     // YARGZ MATEY
-    yargs.argv;
+    return yargs.argv;
   }
 
 
@@ -443,7 +443,7 @@ module.exports = class Cli {
     }
 
     // Initialize
-    this.init(yargs, tasks, config, userConfig);
+    return this.init(yargs, tasks, config, userConfig);
   };
 
   /*

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "build:site": "vuepress build website -d _site",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "generate-tests": "leia \"examples/**/README.md\" test -r 2 -s 'Start up tests' -t 'Verification commands' -c 'Destroy tests' --split-file",
+    "delete-generated-tests": "rm -rf test/*.func.js test/split-file.txt",
     "lint": "eslint --quiet --no-ignore api bin experimental integrations lib plugins scripts test metrics",
     "lint:sites": "eslint  --quiet --ext .js,.vue --config .eslintrc.vuepress.json blog/.vuepress docs/.vuepress events/.vuepress website/.vuepress",
     "pkg:cli": "node ./scripts/pkg.js",

--- a/plugins/lando-tooling/lib/utils.js
+++ b/plugins/lando-tooling/lib/utils.js
@@ -77,12 +77,16 @@ const handleDynamic = (config, options = {}, answers = {}) => {
  * Helper to process args
  *
  * We assume pass through commands so let's use argv directly and strip out
- * the first three assuming they are [node, lando.js, options.name]'
+ * the first three assuming they are [node, lando.js, options.name]'.
+ * If the third argument is a '--', e.g. [node, lando.js, --, options.name],
+ * then the first four arguments are stripped out instead.
  * Check to see if we have global lando opts and remove them if we do
  */
 const handleOpts = (config, argopts = []) => {
-  // Append any user specificed opts
-  argopts = argopts.concat(process.argv.slice(3));
+  // Fetch the argument processor index.
+  const index = process.argv.length > 3 && process.argv[2] === '--' ? 4 : 3;
+  // Append any user specified opts
+  argopts = argopts.concat(process.argv.slice(index));
   // If we have no args then just return right away
   if (_.isEmpty(argopts)) return config;
   // If this is not a CLI then we can pass right back

--- a/test/lando-tooling.spec.js
+++ b/test/lando-tooling.spec.js
@@ -1,0 +1,60 @@
+/**
+ * Tests for the lando tooling plugin.
+ * @file lando-tooling.spec.js
+ */
+
+'use strict';
+
+const originalArgv = process.argv;
+const Cli = require('./../lib/cli');
+const landoToolingUtils = require('./../plugins/lando-tooling/lib/utils');
+const chai = require('chai');
+chai.should();
+
+const setInitialArgv = function(argv) {
+  Object.defineProperty(process, 'argv', {value: argv});
+  // Emulate a Lando node CLI.
+  process.lando = 'node';
+};
+const resetArgv = function() {
+  Object.defineProperty(process, 'argv', {value: originalArgv});
+  delete process.lando;
+};
+
+const fakeTask = {
+  command: 'task',
+  describe: 'desc',
+  run: options => options,
+};
+
+describe('lando-tooling', () => {
+  describe('#lando-tooling-utils', () => {
+    it('should pass options delimiter to backend', () => {
+      setInitialArgv(['node', 'lando.js', 'task', '--', '-vvv']);
+      const cli = new Cli();
+      const task = cli.parseToYargs(fakeTask);
+      task.handler = argv => argv; // Use a noop handler.
+      const args = cli.run([task]);
+      let config = landoToolingUtils.parseConfig(['task'], 'simple-service', {}, args);
+      config.should.have.lengthOf(1);
+      let configEntry = config[0];
+      configEntry.command.should.deep.equal(['task', '--', '-vvv']);
+      configEntry.args.should.deep.equal(['--', '-vvv']);
+      resetArgv();
+    });
+
+    it('should ignore initial options delimiter', () => {
+      setInitialArgv(['node', 'lando.js', '--', 'task', '--', '-vvv']);
+      const cli = new Cli();
+      const task = cli.parseToYargs(fakeTask);
+      task.handler = argv => argv; // Use a noop handler.
+      const args = cli.run([task]);
+      let config = landoToolingUtils.parseConfig(['task'], 'simple-service-2', {}, args);
+      config.should.have.lengthOf(1);
+      let configEntry = config[0];
+      configEntry.command.should.deep.equal(['task', '--', '-vvv']);
+      configEntry.args.should.deep.equal(['--', '-vvv']);
+      resetArgv();
+    });
+  });
+});


### PR DESCRIPTION
Hi @pirog,

Here's a PR addressing the #2439 issue with regards to [POSIX option processing](https://unix.stackexchange.com/a/570733).

I added both functional and unit tests, I think the unit test may be removed as I don't think it really does much.

The functional test may be tested by running:

```bash
yarn generate-tests && yarn mocha --timeout 900000 test/tooling-example.func.js
```
