### PR TITLE
Use specified database env in pantheon pull command. lando/lando#2568

### DIFF
--- a/integrations/lando-pantheon/lib/pull.js
+++ b/integrations/lando-pantheon/lib/pull.js
@@ -73,11 +73,25 @@ const frameworkType = (framework = 'drupal8') => {
 const buildDbPullCommand = ({framework = 'drupal8', drush_version = 8} = {}) => {
   // Wordpress
   if (frameworkType(framework) === 'pressy') {
-    return 'terminus remote:wp -- db export -';
+    return 'terminus remote:wp';
   }
 
   // Drupaly
-  return 'terminus remote:drush -- sql-dump --structure-tables-list=cache,cache_*';
+  return 'terminus remote:drush';
+};
+
+// Helper to build db pull command options. This is needed because
+// integrations/lando-pantheon/scripts/pull.sh needs to concatenate the
+// specified <site.env> between the command returned from buildDbPullCommand()
+// above and these options.
+const buildDbPullCommandOptions = ({framework = 'drupal8', drush_version = 8} = {}) => {
+  // Wordpress
+  if (frameworkType(framework) === 'pressy') {
+    return '-- db export -';
+  }
+
+  // Drupaly
+  return '-- sql-dump --structure-tables-list=cache,cache_*';
 };
 
 // Helper to populate defaults
@@ -99,6 +113,7 @@ const getDefaults = (task, options) => {
   // Set envvars
   task.env = {
     LANDO_DB_PULL_COMMAND: buildDbPullCommand(options),
+    LANDO_DB_PULL_COMMAND_OPTIONS: buildDbPullCommandOptions(options),
     LANDO_DB_USER_TABLE: flavor === 'pressy' ? 'wp_users' : 'users',
     LANDO_LEIA: _.toInteger(options._app._config.leia),
   };

--- a/integrations/lando-pantheon/scripts/pull.sh
+++ b/integrations/lando-pantheon/scripts/pull.sh
@@ -128,7 +128,17 @@ if [ "$DATABASE" != "none" ]; then
   # Holla at @uberhacker for this fu
   FALLBACK_PULL_DB="$(echo $(terminus connection:info $SITE.$DATABASE --field=mysql_command) | sed 's,^mysql,mysqldump --no-autocommit --single-transaction --opt -Q,')"
   LOCAL_MYSQL_CONNECT_STRING="mysql --user=pantheon --password=pantheon --database=pantheon --host=database --port=3306"
-  PULL_DB=${LANDO_DB_PULL_COMMAND:-${FALLBACK_PULL_DB}}
+
+  # This condition will never be met, because buildDbPullCommand() in
+  # integrations/lando-pantheon/lib/pull.js will always return something.
+  if [ -z "$LANDO_DB_PULL_COMMAND" ]; then
+    PULL_DB=$FALLBACK_PULL_DB
+  else
+    # Make sure the terminus command returned from buildDbPullCommand() has the
+    # correct <site.env> specified.
+    PULL_DB="$LANDO_DB_PULL_COMMAND $SITE.$DATABASE $LANDO_DB_PULL_COMMAND_OPTIONS"
+  fi
+
   PULL_DB_CHECK_TABLE=${LANDO_DB_USER_TABLE:-users}
 
   # For some reason terminus remote:thing commands do not return when run through LEIA so we are hacking this for now


### PR DESCRIPTION
As described in #2568, since v.3.0.8 `lando pull` no longer respects the `--database` option, instead always pulling the `dev` environment's database. This pull request fixes the issue by breaking up the `LANDO_DB_PULL_COMMAND` var into two variables provided by two functions in the js, then re-concatenating them with the `<site.env>` argument between in the shell script. There may be a prettier way to do this with some shell string interpolation trickery, but I could not figure it out.

I am not sure what is the best way to test this, given that it depends on a working Pantheon project with multiple environments.

- [x] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/help)
- [ ] My code includes a [functional test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes a [unit test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

