### PR TITLE
Drupal 9 is no longer in development

### DIFF
--- a/docs/config/drupal9.md
+++ b/docs/config/drupal9.md
@@ -9,7 +9,7 @@ Drupal is a free and open source content-management framework written in PHP and
 Lando offers a configurable [recipe](./../config/recipes.md) for developing [Drupal 9](https://drupal.org/) apps.
 
 ::: warning This is a new recipe!
-This is a relatively new recipe and Drupal 9 is still in development. As such this recipe should be consider **beta** quality.
+This is a relatively new recipe. As such this recipe should be consider **beta** quality.
 :::
 
 [[toc]]

--- a/docs/config/drupal9.md
+++ b/docs/config/drupal9.md
@@ -9,7 +9,7 @@ Drupal is a free and open source content-management framework written in PHP and
 Lando offers a configurable [recipe](./../config/recipes.md) for developing [Drupal 9](https://drupal.org/) apps.
 
 ::: warning This is a new recipe!
-This is a relatively new recipe. As such this recipe should be consider **beta** quality.
+This is a relatively new recipe. As such this recipe should be considered **beta** quality.
 :::
 
 [[toc]]


### PR DESCRIPTION
Drupal 9 was released on June 3, 2020: https://www.drupal.org/docs/understanding-drupal/drupal-9-release-date-and-what-it-means

Removing inaccurate statement from the docs. Also, I just tested and the recipe worked fine for me, so it's possible this entire warning could be deleted too, but was less sure about that. :)