### PR TITLE
Fix broken link to Drush install docs

### DIFF
--- a/docs/config/drupal7.md
+++ b/docs/config/drupal7.md
@@ -165,7 +165,7 @@ config:
 
 #### Using a site-local Drush
 
-While Lando will globally install Drush for you it is increasingly common and in some cases a straight-up best practice to [install a site-local Drush](https://docs.drush.org/en/master/install/) by requiring it in your projects `composer.json` file.
+While Lando will globally install Drush for you it is increasingly common and in some cases a straight-up best practice to [install a site-local Drush](https://www.drush.org/install/) by requiring it in your projects `composer.json` file.
 
 Because of how Lando's [php service](./php.md) sets up its [`PATH`](./php.md#path-considerations) this means that if you have indeed installed Drush on your own via `composer` Lando will use yours over its own. Said more explicitly: **if you've required `drush` via `composer` in your application then this recipe will use your `drush` and not the one you've specified in this recipes config.**
 

--- a/docs/config/drupal8.md
+++ b/docs/config/drupal8.md
@@ -165,7 +165,7 @@ config:
 
 #### Using a site-local Drush
 
-While Lando will globally install Drush for you, it is increasingly common and in some cases a straight-up best practice to [install a site-local Drush](https://docs.drush.org/en/master/install/) by requiring it in your projects `composer.json` file.
+While Lando will globally install Drush for you, it is increasingly common and in some cases a straight-up best practice to [install a site-local Drush](https://www.drush.org/install/) by requiring it in your projects `composer.json` file.
 
 Because of how Lando's [php service](./php.md) sets up its [`PATH`](./php.md#path-considerations), this means that if you have indeed installed Drush on your own via `composer` Lando will use yours over its own. Said more explicitly: **if you've required `drush` via `composer` in your application then this recipe will use your `drush` and not the one you've specified in this recipes config.**
 

--- a/docs/config/drupal9.md
+++ b/docs/config/drupal9.md
@@ -139,7 +139,7 @@ config:
 
 ### Using Drush
 
-By default our Drupal 9 recipe will globally install the [latest version of Drush 10](http://docs.drush.org/en/master/install/). However, on Drupal 9 this is not really supported anymore, so we _highly recommend_ you install a site-local Drush so that things work as expected.
+By default our Drupal 9 recipe will globally install the [latest version of Drush 10](https://www.drush.org/install/). However, on Drupal 9 this is not really supported anymore, so we _highly recommend_ you install a site-local Drush so that things work as expected.
 
 #### Using a site-local Drush
 

--- a/docs/config/drupal9.md
+++ b/docs/config/drupal9.md
@@ -143,7 +143,7 @@ By default our Drupal 9 recipe will globally install the [latest version of Drus
 
 #### Using a site-local Drush
 
-You will want to [install a site-local Drush](https://docs.drush.org/en/master/install/) by requiring it in your projects `composer.json` file.
+You will want to [install a site-local Drush](https://www.drush.org/install/) by requiring it in your projects `composer.json` file.
 
 ```bash
 lando composer require drush/drush

--- a/plugins/lando-recipes/lib/warnings.js
+++ b/plugins/lando-recipes/lib/warnings.js
@@ -9,5 +9,5 @@ exports.drushWarn = version => ({
     'This version of drush prefers a site-local installation',
     'We recommend you install drush that way, see:',
   ],
-  url: 'https://docs.drush.org/en/master/install/',
+  url: 'https://www.drush.org/install/',
 });


### PR DESCRIPTION
In several places in the docs, there is reference to https://docs.drush.org/en/master/install/, however this page is a 404.

The new location seems to be https://www.drush.org/install/, so updated all instances to that instead.