### PR TITLE
Issue #2603: Note that only x86 will work with our Docker images

### DIFF
--- a/docs/basics/installation.md
+++ b/docs/basics/installation.md
@@ -32,7 +32,7 @@ Note that Lando is basically a PaaS running on your computer and as such we don'
 
 You _can_ run Lando using the below but your experience may be less than ideal.
 
-*   2-core processor
+*   2-core x86-based processor (Other architectures won't work with our images)
 *   4GB+ RAM
 *   25GB+ of available disk space
 


### PR DESCRIPTION
This just calls out processor architecture explicitly in the installation docs. When Apple Silicon launches, we'll have to see how that plays with Docker/Lando too.