### PR TITLE
Remove X-Frame-Options SAMEORIGIN header in default nginx configs

### DIFF
--- a/docs/help/2020-changelog.md
+++ b/docs/help/2020-changelog.md
@@ -1,5 +1,7 @@
 # 2020
 
+* Removed `X-Frame-Options SAMEORIGIN` header for Nginx service default config [#2648](https://github.com/lando/lando/pull/2648)
+
 ## v3.0.16 - [October 16, 2020](https://github.com/lando/lando/releases/tag/v3.0.16)
 
 Lando is **free** and **open source** software that relies on contributions from developers like you! If you like Lando then help us spend more time making, updating and supporting it by [contributing](https://github.com/sponsors/lando).

--- a/examples/nginx/config/server.conf
+++ b/examples/nginx/config/server.conf
@@ -21,7 +21,6 @@ http {
     fastcgi_buffers 16 16k;
     fastcgi_buffer_size 32k;
 
-    add_header X-Frame-Options SAMEORIGIN;
     client_body_temp_path  "{{NGINX_TMPDIR}}/client_body" 1 2;
     proxy_temp_path "{{NGINX_TMPDIR}}/proxy" 1 2;
     fastcgi_temp_path "{{NGINX_TMPDIR}}/fastcgi" 1 2;

--- a/examples/nginx/config/server2.conf
+++ b/examples/nginx/config/server2.conf
@@ -16,7 +16,6 @@ http {
                        '"$request" $status  $body_bytes_sent "$http_referer" '
                        '"$http_user_agent" "$http_x_forwarded_for"';
     access_log    "/opt/bitnami/nginx/logs/access.log";
-    add_header    X-Frame-Options SAMEORIGIN;
 
     client_body_temp_path  "/opt/bitnami/nginx/tmp/client_body" 1 2;
     proxy_temp_path        "/opt/bitnami/nginx/tmp/proxy" 1 2;

--- a/plugins/lando-services/services/nginx/nginx.conf
+++ b/plugins/lando-services/services/nginx/nginx.conf
@@ -17,7 +17,6 @@ http {
     fastcgi_buffers 16 16k;
     fastcgi_buffer_size 32k;
 
-    add_header    X-Frame-Options SAMEORIGIN;
     client_body_temp_path  "/opt/bitnami/nginx/tmp/client_body" 1 2;
     proxy_temp_path        "/opt/bitnami/nginx/tmp/proxy" 1 2;
     fastcgi_temp_path      "/opt/bitnami/nginx/tmp/fastcgi" 1 2;

--- a/plugins/lando-services/services/nginx/nginx.conf.tpl
+++ b/plugins/lando-services/services/nginx/nginx.conf.tpl
@@ -23,7 +23,6 @@ http {
     fastcgi_buffers 16 16k;
     fastcgi_buffer_size 32k;
 
-    add_header X-Frame-Options SAMEORIGIN;
     client_body_temp_path  "{{NGINX_TMPDIR}}/client_body" 1 2;
     proxy_temp_path "{{NGINX_TMPDIR}}/proxy" 1 2;
     fastcgi_temp_path "{{NGINX_TMPDIR}}/fastcgi" 1 2;


### PR DESCRIPTION
I see the value in this header for a production environment, but not so much for a development environment and I think it would be better omitted by default. I’m not 100% sure, but I don’t think the Apache service adds the header, so this would make the two services more swappable. My use case is working on an embed feature for a project, I would prefer to leave adding that header up to my application. I also removed the header from the examples.

- [x] My code includes the latest code from the `master` branch
- [x] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/help)
- ~~My code includes a [functional test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable~~
- ~~My code includes a [unit test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable~~
- ~~My code includes documentation updates if applicable.~~
- [ ] My code passes relevant CI status checks
- [x] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

