### PR TITLE
#2685 Lagoon pull/push support for multiple env name formats

### DIFF
--- a/integrations/lando-lagoon/lib/pull.js
+++ b/integrations/lando-lagoon/lib/pull.js
@@ -13,7 +13,7 @@ const getEnvironmentChoices = (key, lando, projectName) => {
   const api = new LagoonApi(key, lando);
   return api.auth().then(() => api.getEnvironments(projectName).then(environments => {
     return _(environments)
-      .map(env => ({name: env.name, value: env.name}))
+      .map(env => ({name: env.openshiftProjectName, value: env.openshiftProjectName}))
       .concat([{name: 'none', value: 'none'}])
       .value();
   }));

--- a/integrations/lando-lagoon/scripts/lagoon-pull.sh
+++ b/integrations/lando-lagoon/scripts/lagoon-pull.sh
@@ -93,9 +93,14 @@ while (( "$#" )); do
   esac
 done
 
-# Set values from input
-LANDO_DB_ALIAS="lagoon.${LANDO_LAGOON_PROJECT}-${LANDO_DB_ALIAS}"
-LANDO_FILES_ALIAS="lagoon.${LANDO_LAGOON_PROJECT}-${LANDO_FILES_ALIAS}"
+# Dynamically prefix alias if project name was not included
+if [[ "${LANDO_DB_ALIAS}" != "${LANDO_LAGOON_PROJECT}"* ]]; then
+  LANDO_DB_ALIAS="${LANDO_LAGOON_PROJECT}-${LANDO_DB_ALIAS}"
+  LANDO_FILES_ALIAS="${LANDO_LAGOON_PROJECT}-${LANDO_FILES_ALIAS}"
+fi
+# Prefix aliases with lagoon.
+LANDO_DB_ALIAS="lagoon.${LANDO_DB_ALIAS}"
+LANDO_FILES_ALIAS="lagoon.${LANDO_FILES_ALIAS}"
 
 if [ $DEBUG = 1 ]; then
   echo "--"

--- a/integrations/lando-lagoon/scripts/lagoon-push.sh
+++ b/integrations/lando-lagoon/scripts/lagoon-push.sh
@@ -94,9 +94,14 @@ while (( "$#" )); do
   esac
 done
 
-# Set values from input
-LANDO_DB_ALIAS="lagoon.${LANDO_LAGOON_PROJECT}-${LANDO_DB_ALIAS}"
-LANDO_FILES_ALIAS="lagoon.${LANDO_LAGOON_PROJECT}-${LANDO_FILES_ALIAS}"
+# Dynamically prefix alias if project name was not included
+if [[ "${LANDO_DB_ALIAS}" != "${LANDO_LAGOON_PROJECT}"* ]]; then
+  LANDO_DB_ALIAS="${LANDO_LAGOON_PROJECT}-${LANDO_DB_ALIAS}"
+  LANDO_FILES_ALIAS="${LANDO_LAGOON_PROJECT}-${LANDO_FILES_ALIAS}"
+fi
+# Prefix aliases with lagoon.
+LANDO_DB_ALIAS="lagoon.${LANDO_DB_ALIAS}"
+LANDO_FILES_ALIAS="lagoon.${LANDO_FILES_ALIAS}"
 
 if [ $DEBUG = 1 ]; then
   echo "--"


### PR DESCRIPTION
Adds long and short environment name support to lando pull/push within the Lagoon recipe.

```
# Long format
lando pull --database drupal9-lando-postgres-main --files drupal9-lando-postgres-main
lando push --database drupal9-lando-postgres-main --files drupal9-lando-postgres-main

# Short format
lando pull --database main --files main
lando push --database main --files main
```