### PR TITLE
Use new setting instead of deprecated config for temp path

### DIFF
--- a/integrations/lando-platformsh/lib/overrides.js
+++ b/integrations/lando-platformsh/lib/overrides.js
@@ -3,7 +3,7 @@
 const overrides = {};
 
 // DRUPAL 8
-overrides['d8config:system.file:path:temporary'] = '/tmp';
+overrides['d8settings:file_temp_path'] = '/tmp';
 overrides['d8settings:skip_permissions_hardening'] = 1;
 
 module.exports = overrides;


### PR DESCRIPTION
We will get to your PR as soon as we can but in the meantime you might want to check to make sure you have done the following. **The more boxes you can check the easier it will be for us to merge in your changes with confidence**

- [x] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/help)
- [ ] My code includes a [functional test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes a [unit test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

This just updates the default overrides to use the new, non-deprecated setting for Drupal 8.8+: https://www.drupal.org/node/3039255

The old key won't work in Drupal 9.

