### PR TITLE
Added support for installing the latest composer version 1 or 2, snapshot and preview.

### DIFF
--- a/plugins/lando-services/scripts/install-composer.sh
+++ b/plugins/lando-services/scripts/install-composer.sh
@@ -6,7 +6,18 @@ VERSION="$1"
 
 # NOTE: we should have better protections here
 php -r "copy('https://getcomposer.org/installer', '/tmp/composer-setup.php');"
-php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer --version="$VERSION"
+if [ "$VERSION" = '1-latest' ]; then
+  php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer --1
+elif [ "$VERSION" = '2-latest' ]; then
+  php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer --2
+elif [ "$VERSION" = 'preview' ]; then
+  php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer --preview
+elif [ "$VERSION" = 'snapshot' ]; then
+  php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer --snapshot
+else
+  php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer --version="$VERSION"
+fi
+
 php -r "unlink('/tmp/composer-setup.php');"
 
 # If this is version 2 then let's make sure hirak/prestissimo is removed


### PR DESCRIPTION
Added support for installing the latest composer version 1 or 2, snapshot and preview.

`composer_version: '1-latest'`
`composer_version: '2-latest'`
`composer_version: 'snapshot'`
`composer_version: 'preview'`

I tested each case and it works. What are my next steps?

- [ ] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/help)
- [ ] My code includes a [functional test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes a [unit test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

