### PR TITLE
Modify 'drush la' calls to use 'drush sa' instead with lagoon pull/push

### DIFF
--- a/integrations/lando-lagoon/scripts/lagoon-pull.sh
+++ b/integrations/lando-lagoon/scripts/lagoon-pull.sh
@@ -114,13 +114,13 @@ fi
 
 # Update aliases
 lando_pink "Refreshing aliases..."
-drush la 1>/dev/null
+drush sa 1>/dev/null
 
 # Sync database
 if [ "${LANDO_DB_ALIAS}" != "lagoon.${LANDO_LAGOON_PROJECT}-none" ]; then
   # Validate environment exists
   lando_pink "Validating ${LANDO_DB_ALIAS} exists and you have access to it..."
-  if ! drush la | grep ${LANDO_DB_ALIAS}; then
+  if ! drush sa | grep ${LANDO_DB_ALIAS}; then
     lando_red "$LANDO_DB_ALIAS does not appear to be a valid environment!"
     exit 1
   fi
@@ -144,7 +144,7 @@ fi
 if [ "${LANDO_FILES_ALIAS}" != "lagoon.${LANDO_LAGOON_PROJECT}-none" ]; then
   # Validate environment exists
   lando_pink "Validating ${LANDO_FILES_ALIAS} exists and you have access to it..."
-  if ! drush la | grep ${LANDO_FILES_ALIAS}; then
+  if ! drush sa | grep ${LANDO_FILES_ALIAS}; then
     lando_red "$LANDO_FILES_ALIAS does not appear to be a valid environment!"
     exit 1
   fi

--- a/integrations/lando-lagoon/scripts/lagoon-push.sh
+++ b/integrations/lando-lagoon/scripts/lagoon-push.sh
@@ -115,13 +115,13 @@ fi
 
 # Update aliases
 lando_pink "Refreshing aliases..."
-drush la 1>/dev/null
+drush sa 1>/dev/null
 
 # Sync database
 if [ "${LANDO_DB_ALIAS}" != "lagoon.${LANDO_LAGOON_PROJECT}-none" ]; then
   # Validate environment exists
   lando_pink "Validating ${LANDO_FILES_ALIAS} exists and you have access to it..."
-  if ! drush la | grep ${LANDO_FILES_ALIAS}; then
+  if ! drush sa | grep ${LANDO_FILES_ALIAS}; then
     lando_red "$LANDO_FILES_ALIAS does not appear to be a valid environment!"
     exit 1
   fi
@@ -144,7 +144,7 @@ fi
 if [ "${LANDO_FILES_ALIAS}" != "lagoon.${LANDO_LAGOON_PROJECT}-none" ]; then
   # Validate environment exists
   lando_pink "Validating ${LANDO_FILES_ALIAS} exists and you have access to it..."
-  if ! drush la | grep ${LANDO_FILES_ALIAS}; then
+  if ! drush sa | grep ${LANDO_FILES_ALIAS}; then
     lando_red "$LANDO_FILES_ALIAS does not appear to be a valid environment!"
     exit 1
   fi


### PR DESCRIPTION
I have been attempting to spin up Lagoon sites using Lando and have come across a problem when attempting to pull down a database or files from Lagoon.

At the point in the `lagoon-pull.sh` file where it attempts to retrieve the drush aliases using `drush la` I get the following error:

```
lando pull --database sitename-master --files sitename-master
? Choose a Lagoon account xxx@xxx.zzz
Refreshing aliases...
The drush command 'la' could not be found.  Run `drush cache-clear drush` to clear the commandfile cache if you have installed new extensions.
```

Running the `drush clear-cache drush` does nothing because I cannot find anywhere that references a drush alias for `la`. The closest equivalent is `sa` which is an alias for `site-alias` (or `site:alias` in Drush 9/10)

Here are the documentation links related to site aliases for the different versions of Drush.

- [Drush 10 documentation for site:alias](https://www.drush.org/commands/10.x/site_alias/#aliases)
- [Drush 9 documentation for site:alias](https://drushcommands.com/drush-9x/site/site:alias/)
- [Drush 8 documentation for site-alias](https://drushcommands.com/drush-8x/core/site-alias/)

The site I am spinning up is a Drupal 7 site that has worked well with pygmy but that I'd like to get switched over to Lando if possible. I do not actually know what `drush la` is, whether it is a custom drush command for lando or lagoon (I would presume not), but I also cannot find it listed as an alias in any documentation either, and given that `drush sa` is listed and is a core drush command not requiring any additional modules or custom drush extensions, it felt like probably a safer bet.

I looked around for some unit or functional tests to update, and any docs, but I could not find anything at this time.