### PR TITLE
Lagoon section - Fix typo

### DIFF
--- a/docs/config/lagoon.md
+++ b/docs/config/lagoon.md
@@ -226,7 +226,7 @@ lando pull --database none --files none
 ```
 
 ```bash
-lando pull
+lando push
 
 Push db and files to Lagoon
 


### PR DESCRIPTION
There is a typo in here: https://docs.lando.dev/config/lagoon.html#pulling-and-pushing-databases-and-files

In the `push` section the command says `pull`.