### PR TITLE
2762 - Lagoon Pull - Fix hardcoded public file paths and minor bugs

### DIFF
--- a/integrations/lando-lagoon/scripts/lagoon-pull.sh
+++ b/integrations/lando-lagoon/scripts/lagoon-pull.sh
@@ -127,7 +127,7 @@ if [ "${LANDO_DB_ALIAS}" != "lagoon.${LANDO_LAGOON_PROJECT}-none" ]; then
   # Validate environment exists
   lando_pink "Validating database alias @${LANDO_DB_ALIAS} exists and you have access to it..."
   if ! drush la | grep -q ${LANDO_DB_ALIAS}; then
-    lando_red "@$LANDO_DB_ALIAS does not appear to be a valid environment!"
+    lando_red "@${LANDO_DB_ALIAS} does not appear to be a valid environment!"
     exit 1
   fi
 
@@ -138,7 +138,7 @@ if [ "${LANDO_DB_ALIAS}" != "lagoon.${LANDO_LAGOON_PROJECT}-none" ]; then
     exit 1
   fi
 
-  lando_green "Database alias @$LANDO_DB_ALIAS access confirmed!"
+  lando_green "Database alias @${LANDO_DB_ALIAS} access confirmed!"
 
   # Suppress drush messaging by assigning output
   echo "Destroying all current tables in database if needed... "
@@ -156,7 +156,7 @@ if [ "${LANDO_FILES_ALIAS}" != "lagoon.${LANDO_LAGOON_PROJECT}-none" ]; then
   # Validate environment exists
   lando_pink "Validating file alias @${LANDO_FILES_ALIAS} exists and you have access to it..."
   if ! drush la | grep -q ${LANDO_FILES_ALIAS}; then
-    lando_red "@$LANDO_FILES_ALIAS does not appear to be a valid environment!"
+    lando_red "@${LANDO_FILES_ALIAS} does not appear to be a valid environment!"
     exit 1
   fi
 
@@ -169,13 +169,13 @@ if [ "${LANDO_FILES_ALIAS}" != "lagoon.${LANDO_LAGOON_PROJECT}-none" ]; then
   lando_green "Files alias @${LANDO_FILES_ALIAS} access confirmed!"
 
   if ! drush "@${LANDO_FILES_ALIAS}" status | grep -q "File directory path"; then
-    lando_red "Unable to pull files from $LANDO_FILES_ALIAS without a file directory path specified. Set up or import a database first."
+    lando_red "Unable to pull files from ${LANDO_FILES_ALIAS} without a file directory path specified. Set up or import a database first."
     exit 1
   else
     DRUPAL_FILES_PATH=$(drush @${LANDO_FILES_ALIAS} dd files | tr -d '\n' 2>/dev/null)
   fi
 
-  lando_pink "Attemping to sync files to/from directory: $DRUPAL_FILES_PATH"
+  lando_pink "Attemping to sync files to/from directory: ${DRUPAL_FILES_PATH}"
 
   # Import files with rsync
   LANDO_SSH_KEY=${LANDO_SSH_KEY} drush rsync "@${LANDO_FILES_ALIAS}":${DRUPAL_FILES_PATH} ${DRUPAL_FILES_PATH} -y

--- a/integrations/lando-lagoon/scripts/lagoon-pull.sh
+++ b/integrations/lando-lagoon/scripts/lagoon-pull.sh
@@ -27,6 +27,9 @@ LANDO_SSH_KEY=
 LANDO_DB_ALIAS="none"
 LANDO_FILES_ALIAS="none"
 
+# Set drupal paths
+DRUPAL_FILES_PATH="web/sites/default/files"
+
 # Auth options
 AUTH_HOST="ssh.lagoon.amazeeio.cloud"
 AUTH_USER="lagoon"
@@ -96,8 +99,11 @@ done
 # Dynamically prefix alias if project name was not included
 if [[ "${LANDO_DB_ALIAS}" != "${LANDO_LAGOON_PROJECT}"* ]]; then
   LANDO_DB_ALIAS="${LANDO_LAGOON_PROJECT}-${LANDO_DB_ALIAS}"
+fi
+if [[ "${LANDO_FILES_ALIAS}" != "${LANDO_LAGOON_PROJECT}"* ]]; then
   LANDO_FILES_ALIAS="${LANDO_LAGOON_PROJECT}-${LANDO_FILES_ALIAS}"
 fi
+
 # Prefix aliases with lagoon.
 LANDO_DB_ALIAS="lagoon.${LANDO_DB_ALIAS}"
 LANDO_FILES_ALIAS="lagoon.${LANDO_FILES_ALIAS}"
@@ -119,15 +125,20 @@ drush la 1>/dev/null
 # Sync database
 if [ "${LANDO_DB_ALIAS}" != "lagoon.${LANDO_LAGOON_PROJECT}-none" ]; then
   # Validate environment exists
-  lando_pink "Validating ${LANDO_DB_ALIAS} exists and you have access to it..."
-  if ! drush la | grep ${LANDO_DB_ALIAS}; then
-    lando_red "$LANDO_DB_ALIAS does not appear to be a valid environment!"
+  lando_pink "Validating database alias @${LANDO_DB_ALIAS} exists and you have access to it..."
+  if ! drush la | grep -q ${LANDO_DB_ALIAS}; then
+    lando_red "@$LANDO_DB_ALIAS does not appear to be a valid environment!"
     exit 1
   fi
 
+
   # Validate we can ping the remote environment
-  drush "@${LANDO_DB_ALIAS}" status -y
-  lando_green "Confirmed!"
+  if ! drush "@${LANDO_DB_ALIAS}" status -y >/dev/null; then
+    lando_red "Database alias @${LANDO_DB_ALIAS} access failed!"
+    exit 1
+  fi
+
+  lando_green "Database alias @$LANDO_DB_ALIAS access confirmed!"
 
   # Suppress drush messaging by assigning output
   echo "Destroying all current tables in database if needed... "
@@ -137,27 +148,39 @@ if [ "${LANDO_DB_ALIAS}" != "lagoon.${LANDO_LAGOON_PROJECT}-none" ]; then
   echo "Pulling your database... This miiiiight take a minute"
   LANDO_SSH_KEY=${LANDO_SSH_KEY} drush "@${LANDO_DB_ALIAS}" sql:dump -y | drush sql:cli -y
 else
-  echo "Skipping database"
+  lando_green "Skipping database"
 fi
 
 # Sync files
 if [ "${LANDO_FILES_ALIAS}" != "lagoon.${LANDO_LAGOON_PROJECT}-none" ]; then
   # Validate environment exists
-  lando_pink "Validating ${LANDO_FILES_ALIAS} exists and you have access to it..."
-  if ! drush la | grep ${LANDO_FILES_ALIAS}; then
-    lando_red "$LANDO_FILES_ALIAS does not appear to be a valid environment!"
+  lando_pink "Validating file alias @${LANDO_FILES_ALIAS} exists and you have access to it..."
+  if ! drush la | grep -q ${LANDO_FILES_ALIAS}; then
+    lando_red "@$LANDO_FILES_ALIAS does not appear to be a valid environment!"
     exit 1
   fi
 
   # Validate we can ping the remote environment
-  drush "@${LANDO_FILES_ALIAS}" status -y
-  lando_green "Confirmed!"
+  if ! drush "@${LANDO_FILES_ALIAS}" status -y >/dev/null; then
+    lando_red "Files alias @${LANDO_FILES_ALIAS} access failed!"
+    exit 1
+  fi
+
+  lando_green "Files alias @${LANDO_FILES_ALIAS} access confirmed!"
+
+  if ! drush "@${LANDO_FILES_ALIAS}" status | grep -q "File directory path"; then
+    lando_red "Unable to pull files from $LANDO_FILES_ALIAS without a file directory path specified. Set up or import a database first."
+    exit 1
+  else
+    DRUPAL_FILES_PATH=$(drush @${LANDO_FILES_ALIAS} dd files | tr -d '\n' 2>/dev/null)
+  fi
+
+  lando_pink "Attemping to sync files to/from directory: $DRUPAL_FILES_PATH"
 
   # Import files with rsync
-  echo "Pulling files..."
-  LANDO_SSH_KEY=${LANDO_SSH_KEY} drush rsync @${LANDO_FILES_ALIAS}:web/sites/default/files web/sites/default -y
+  LANDO_SSH_KEY=${LANDO_SSH_KEY} drush rsync "@${LANDO_FILES_ALIAS}":${DRUPAL_FILES_PATH} ${DRUPAL_FILES_PATH} -y
 else
-  echo "Skipping files"
+  lando_green "Skipping files"
 fi
 
 # Finish up!


### PR DESCRIPTION
- Fix problem with hardcoded public file paths in lagoon-pull.sh
- Fix problem with duplicated LANDO_LAGOON_PROJECT in files alias if no database import selected
- Clean up output to prevent flooding the console with irrelevant or duplicative drush output during pull process
- Add additional debug/notice messaging where appropriate