### PR TITLE
Allow setting node service port to false.

### DIFF
--- a/docs/config/node.md
+++ b/docs/config/node.md
@@ -78,7 +78,7 @@ services:
 
 ### Setting a port
 
-While we assume your `node` service is running on port `80`, we recognize that many `node` app's also run on port `3000` or otherwise. You can easily change our default to match whatever your app needs.
+While we assume your `node` service is running on port `80`, we recognize that many `node` app's also run on port `3000` or otherwise. You can easily change our default to match whatever your app needs. If your `node` service doesn't require an exposed port, you can also set `port` to `false` to disable the default port `80` mapping.
 
 Note that if you set either `port` or `ssl` to a value less than `1024` then Lando will run the `command` as `root` otherwise it will run as the `node` user which for all intents and purposes is `you`.
 

--- a/plugins/lando-services/services/node/builder.js
+++ b/plugins/lando-services/services/node/builder.js
@@ -97,7 +97,7 @@ module.exports = {
           LANDO_WEBROOT_UID: '1000',
           LANDO_WEBROOT_GID: '1000',
         },
-        ports: (options.command !== 'tail -f /dev/null') ? [options.port] : [],
+        ports: (options.command !== 'tail -f /dev/null' && options.port !== false) ? [options.port] : [],
         volumes: options.volumes,
         command: `/bin/sh -c "${options.command}"`,
       };


### PR DESCRIPTION
PR adds the ability to set the port option on the node service to false to disable the default port 80 mapping.

Related to #2768 (after more digging, it appeared to be a relatively simple/low-risk feature to add).