### PR TITLE
Update LEMP example for custom config files

### DIFF
--- a/docs/config/lemp.md
+++ b/docs/config/lemp.md
@@ -166,6 +166,8 @@ Note that you can put your configuration files anywhere inside your application 
 recipe: lemp
 config:
   config:
+    server: config/nginx.conf
+    vhosts: config/default.conf
     php: config/php.ini
     database: config/my-custom.cnf
 ```


### PR DESCRIPTION
Figured that in the example, the config files are listed, but they're not used in the lando config.