### PR TITLE
Updated Redis documentation to match code

### DIFF
--- a/docs/config/redis.md
+++ b/docs/config/redis.md
@@ -12,7 +12,7 @@ You can easily add it to your Lando app by adding an entry to the [services](./.
 
 ## Supported versions
 
-*   [6.0](https://hub.docker.com/_/redis)
+*   [6](https://hub.docker.com/_/redis)
 *   **[5](https://hub.docker.com/_/redis)** **(default)**
 *   [5.0](https://hub.docker.com/_/redis)
 *   [4](https://hub.docker.com/_/redis)

--- a/docs/config/redis.md
+++ b/docs/config/redis.md
@@ -13,6 +13,7 @@ You can easily add it to your Lando app by adding an entry to the [services](./.
 ## Supported versions
 
 *   [6](https://hub.docker.com/_/redis)
+*   [6.0](https://hub.docker.com/_/redis)
 *   **[5](https://hub.docker.com/_/redis)** **(default)**
 *   [5.0](https://hub.docker.com/_/redis)
 *   [4](https://hub.docker.com/_/redis)

--- a/plugins/lando-services/services/redis/builder.js
+++ b/plugins/lando-services/services/redis/builder.js
@@ -8,7 +8,7 @@ module.exports = {
   name: 'redis',
   config: {
     version: '5',
-    supported: ['6', '5', '5.0', '4', '4.0', '2.8'],
+    supported: ['6', '6.0', '5', '5.0', '4', '4.0', '2.8'],
     patchesSupported: true,
     confSrc: __dirname,
     persist: false,


### PR DESCRIPTION
In `plugins/lando-services/services/redis/builder.js` Redis version is defined as `['6', '5', '5.0', '4', '4.0', '2.8']`. This causes an error "redis version 6.0 is not supported" if a user configures their Redis service as `type: redis:6.0`. I suggest matching the docs to code.

