### PR TITLE
Add the render template component

### DIFF
--- a/plugins/lando-services/services/nginx/launch.sh
+++ b/plugins/lando-services/services/nginx/launch.sh
@@ -34,10 +34,17 @@ if [ -f "$PARAMS_SOURCE" ]; then
   cp -f "$PARAMS_SOURCE" "$PARAMS"
 fi
 
+# Unpack components
+if [[ -f "/opt/bitnami/scripts/libcomponent.sh" ]]; then
+. /opt/bitnami/scripts/libcomponent.sh && component_unpack "render-template" "1.0.0-3" --checksum 8179ad1371c9a7d897fe3b1bf53bbe763f94edafef19acad2498dd48b3674efe
+/opt/bitnami/scripts/nginx/postunpack.sh
+fi
+
 # Render the template if render-template exists
 if [ -x "$(command -v render-template)" ]; then
   render-template "$VHOST_SOURCE" > /opt/bitnami/nginx/conf/vhosts/lando.conf
 else
+  lando_info "Command render-template not found, using sed"
   sed 's@{{LANDO_WEBROOT}}@'"${LANDO_WEBROOT}"'@g' "$VHOST_SOURCE" > /opt/bitnami/nginx/conf/vhosts/lando.conf
 fi
 lando_info "Rendered template /tmp/vhosts.lando to /opt/bitnami/nginx/conf/vhosts/lando.conf"


### PR DESCRIPTION
This adds the render template component back to NGINX so we can use env variables inside our NGINX templates.

I'm not sure if (postunpack.sh)[https://github.com/bitnami/bitnami-docker-nginx/blob/master/1.19/debian-10/rootfs/opt/bitnami/scripts/nginx/postunpack.sh] is needed here.

This code is an (almost) direct copy from the (Bitnami docker file)[https://github.com/bitnami/bitnami-docker-nginx/blob/master/1.19/debian-10/Dockerfile].

I've added a conditional check to maintain compatibility with the 1.14 images. 

Relevant issue: https://github.com/lando/lando/issues/2760

I'm aware that we'd need to keep the render-template component up-to-date but this wouldn't be too big of an issue, would it?

- [x] My code includes the latest code from the `master` branch
- [x] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/help)
- [ ] My code includes a [functional test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes a [unit test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.