### PR TITLE
Updates the location the binding.pem is downloaded to for Lockr support

### DIFF
--- a/integrations/lando-pantheon/scripts/auth.sh
+++ b/integrations/lando-pantheon/scripts/auth.sh
@@ -25,20 +25,20 @@ if [ ! -z "$AUTH" ]; then
     terminus site:info $SITE || exit 1
     lando_green "Access confirmed!"
 
-    # LOCKR integration
+    # Lockr integration
     # If we don't have our dev cert already let's get it
-    if ! openssl x509 -noout -text -in /var/www/certs/binding.pem 2>/dev/null | grep Pantheon 1>/dev/null; then
-      echo "Pantheon LOCKR setup"
-      rm -f /var/www/certs/binding.pem
-      $(terminus connection:info $SITE.dev --field=sftp_command):certs/binding.pem /var/www/certs/binding.pem
+    if ! openssl x509 -noout -text -in /certs/binding.pem 2>/dev/null | grep Pantheon 1>/dev/null; then
+      echo "Pantheon Lockr setup"
+      rm -f /certs/binding.pem
+      $(terminus connection:info $SITE.dev --field=sftp_command):certs/binding.pem /certs/binding.pem
     fi
 
     # Lets also check to see if we should refresh our cert
-    if openssl x509 -checkend 86400 -noout -in /var/www/certs/binding.pem; then
+    if openssl x509 -checkend 86400 -noout -in /certs/binding.pem; then
       lando_green "Cert is good!"
     else
-      rm -f /var/www/certs/binding.pem
-      $(terminus connection:info $SITE.dev --field=sftp_command):certs/binding.pem /var/www/certs/binding.pem
+      rm -f /certs/binding.pem
+      $(terminus connection:info $SITE.dev --field=sftp_command):certs/binding.pem /certs/binding.pem
     fi
   fi
 fi

--- a/plugins/lando-core/scripts/add-cert.sh
+++ b/plugins/lando-core/scripts/add-cert.sh
@@ -125,6 +125,9 @@ cp -f /certs/cert.key /certs/server.key
 # Set the cert and key on host to host-uid/gid ownership
 chown "$LANDO_HOST_UID:$LANDO_HOST_GID" "/lando/certs/${LANDO_SERVICE_NAME}.${LANDO_APP_PROJECT}.crt"
 chown "$LANDO_HOST_UID:$LANDO_HOST_GID" "/lando/certs/${LANDO_SERVICE_NAME}.${LANDO_APP_PROJECT}.key"
+# Change permissions on the folder to let others install certs as needed
+chgrp www-data /certs
+chmod 775 /certs
 
 # Trust our root CA
 if [ ! -f "$CA_CERT_CONTAINER" ]; then


### PR DESCRIPTION
Small update to point the download of the binding.pem to the correct folder where Lockr can find it. This is related to https://github.com/lando/lando/issues/2855 in that without the PANTHEON_BINDING not being defined Lockr ceases to work, however we are moving off using that constant and this will be the fix for that issue.