### PR TITLE
Add freetype to GD in the PHP 8 images

### DIFF
--- a/plugins/lando-services/services/php/8.0-apache/Dockerfile
+++ b/plugins/lando-services/services/php/8.0-apache/Dockerfile
@@ -19,6 +19,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     #imagemagick \
     libbz2-dev \
     libc-client-dev \
+    libfreetype6-dev \
     libicu-dev \
     libjpeg62-turbo-dev \
     libkrb5-dev \
@@ -81,5 +82,5 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && rm -rf /var/lib/apt/lists/* && rm -rf && rm -rf /var/lib/cache/* && rm -rf /var/lib/log/* && rm -rf /tmp/* \
   && PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
   && docker-php-ext-install imap \
-  && docker-php-ext-configure gd --enable-gd --with-jpeg --with-webp \
+  && docker-php-ext-configure gd --enable-gd --with-jpeg --with-webp --with-freetype \
   && docker-php-ext-install gd

--- a/plugins/lando-services/services/php/8.0-fpm/Dockerfile
+++ b/plugins/lando-services/services/php/8.0-fpm/Dockerfile
@@ -19,6 +19,7 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
     #imagemagick \
     libbz2-dev \
     libc-client-dev \
+    libfreetype6-dev \
     libicu-dev \
     libjpeg62-turbo-dev \
     libkrb5-dev \
@@ -81,5 +82,5 @@ RUN mkdir -p /usr/share/man/man1 /usr/share/man/man7 \
   && rm -rf /var/lib/apt/lists/* && rm -rf && rm -rf /var/lib/cache/* && rm -rf /var/lib/log/* && rm -rf /tmp/* \
   && PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
   && docker-php-ext-install imap \
-  && docker-php-ext-configure gd --enable-gd --with-jpeg --with-webp \
+  && docker-php-ext-configure gd --enable-gd --with-jpeg --with-webp --with-freetype \
   && docker-php-ext-install gd


### PR DESCRIPTION
- [x] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/help)
- [x] My code includes a [functional test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable (N/A)
- [x] My code includes a [unit test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable (N/A)
- [x] My code includes documentation updates if applicable. (N/A)
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

I was going to update the changelog, but it confuses me as there's no 2021 changelog so left it