### PR TITLE
Attempt to remove prestissimo on all composer versions

### DIFF
--- a/plugins/lando-services/scripts/install-composer.sh
+++ b/plugins/lando-services/scripts/install-composer.sh
@@ -30,7 +30,7 @@ php -r "unlink('/tmp/composer-setup.php');"
 # Check if anything is installed globally
 if [ -f /var/www/.composer/composer.json ]; then
   # If this is version 2 then let's make sure hirak/prestissimo is removed
-  if  composer --version 2>/dev/null | grep "Composer version 2." > /dev/null; then
+  if composer --version 2>/dev/null | grep -E "Composer (version )?2." > /dev/null; then
     composer global remove hirak/prestissimo
   fi
 fi


### PR DESCRIPTION
Prestissimo is only removed on composer branch aliases.

It should support the alternative format as well.

See https://github.com/composer/composer/blob/4e0b8c1/src/Composer/Console/Application.php#L494-L507
