### PR TITLE
Compares vm.max_map_count to ideal value before attempting to change it.

### DIFF
--- a/docs/help/2021-changelog.md
+++ b/docs/help/2021-changelog.md
@@ -1,5 +1,7 @@
 # 2021
 
+* Writes vm.max_map_count only if necessary and writable [#2884](https://github.com/lando/lando/issues/2880).
+
 ## v3.0.26 - [February 23, 2021](https://github.com/lando/lando/releases/tag/v3.0.26)
 
 Lando is **free** and **open source** software that relies on contributions from developers like you! If you like Lando then help us spend more time making, updating and supporting it by [contributing](https://github.com/sponsors/lando).

--- a/installer/linux/scripts/postinst
+++ b/installer/linux/scripts/postinst
@@ -26,8 +26,21 @@ done
 
 # Bump this for ES search things
 MAX_MAP_COUNT=262144
-if [ -f /proc/sys/vm/max_map_count ] && [ "$(sysctl -n vm.max_map_count)" -lt "$MAX_MAP_COUNT" ]; then
-  sysctl -w vm.max_map_count=$MAX_MAP_COUNT
+MMC_PARAMETER_PATH=/proc/sys/vm/max_map_count
+if [ -f "$MMC_PARAMETER_PATH" ] && [ "$(sysctl -n vm.max_map_count)" -lt "$MAX_MAP_COUNT" ]; then
+  if [ -w "$MMC_PARAMETER_PATH" ]; then
+    sysctl -w vm.max_map_count=$MAX_MAP_COUNT
+  else
+    CURRENT_VALUE=$(sysctl -n vm.max_map_count)
+    cat <<EOF
+The value of the kernel parameter 'vm.max_map_count' is currently set to $CURRENT_VALUE.
+For best performance, we recommend that this be set to at least $MAX_MAP_COUNT.
+We attempted to set this value automatically, but were unable.
+To try to set this value yourself, run the following command:
+
+            sysctl -w vm.max_map_count=$MAX_MAP_COUNT
+EOF
+  fi
 fi
 
 # @TODO: Wait for GUI

--- a/installer/linux/scripts/postinst
+++ b/installer/linux/scripts/postinst
@@ -19,8 +19,9 @@ ln -sf "$LANDO_ROOT/bin/lando" /usr/local/bin/lando
 SUDOERS=$(awk -F':' '$1 == "sudo" {print $4}' /etc/group)
 
 # Bump this for ES search things
-if [ -f /proc/sys/vm/max_map_count ]; then
-  sysctl -w vm.max_map_count=262144
+MAX_MAP_COUNT=262144
+if [ -f /proc/sys/vm/max_map_count ] && [ "$(sysctl -n vm.max_map_count)" -lt "$MAX_MAP_COUNT" ]; then
+  sysctl -w vm.max_map_count=$MAX_MAP_COUNT
 fi
 
 # Transform sudoers into IFS default separation and loop

--- a/installer/linux/scripts/postinst
+++ b/installer/linux/scripts/postinst
@@ -18,17 +18,17 @@ ln -sf "$LANDO_ROOT/bin/lando" /usr/local/bin/lando
 # Strictly grab all sudoers
 SUDOERS=$(awk -F':' '$1 == "sudo" {print $4}' /etc/group)
 
-# Bump this for ES search things
-MAX_MAP_COUNT=262144
-if [ -f /proc/sys/vm/max_map_count ] && [ "$(sysctl -n vm.max_map_count)" -lt "$MAX_MAP_COUNT" ]; then
-  sysctl -w vm.max_map_count=$MAX_MAP_COUNT
-fi
-
 # Transform sudoers into IFS default separation and loop
 for u in ${SUDOERS//,/ }
 do
   usermod -a -G docker $u
 done
+
+# Bump this for ES search things
+MAX_MAP_COUNT=262144
+if [ -f /proc/sys/vm/max_map_count ] && [ "$(sysctl -n vm.max_map_count)" -lt "$MAX_MAP_COUNT" ]; then
+  sysctl -w vm.max_map_count=$MAX_MAP_COUNT
+fi
 
 # @TODO: Wait for GUI
 # Add an entry to the system menu


### PR DESCRIPTION
See #2880.  I also took the liberty of moving the chunk of code slightly so that the sudoers-related code would remain colocated.

**EDIT**: This is a very conservative attempt to fix the issue at hand -- there's certainly more I could do, and I'm happy to extend this PR further if desired.

**EDIT 2**: Added some code to further test the writability of the kernel parameter before attempting to write to it, and if it's not writeable, show some explanatory text to the user.

- [x] My code includes the latest code from the `master` branch
- [x] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/help)
- [ ] My code includes a [functional test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes a [unit test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes documentation updates if applicable.
- [x] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.
