### PR TITLE
Use semver's coerce to get a valid semantic version number for PHP.

### DIFF
--- a/plugins/lando-services/services/php/builder.js
+++ b/plugins/lando-services/services/php/builder.js
@@ -140,7 +140,7 @@ module.exports = {
 
       // Shift on the docker entrypoint if this is a more recent version
       // @TODO: can we assume we will always have major.minor for php release?
-      if (options.version !== 'custom' && semver.gt(`${options.version}.0`, '5.5.0')) {
+      if (options.version !== 'custom' && semver.gt(semver.coerce(options.version), '5.5.0')) {
         options.command.unshift('docker-php-entrypoint');
       }
 


### PR DESCRIPTION
Think this'll work.

- [x] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/help)
- [ ] My code includes a [functional test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes a [unit test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

