### PR TITLE
Setting `node --no-warnings` in an alternate way

### DIFF
--- a/bin/lando.js
+++ b/bin/lando.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --no-warnings
+#!/usr/bin/env NODE_OPTIONS=--no-warnings node
 
 /**
  * Main CLI entrypoint to use the lando libraries


### PR DESCRIPTION
Setting `node --no-warnings` in an alternate way that will (hopefully) work with all `env` implementations.
