### PR TITLE
Add support for pantheon.local.yml override

### DIFF
--- a/contributors.yml
+++ b/contributors.yml
@@ -198,3 +198,13 @@
   title: Contributor
   pic: 'https://www.gravatar.com/avatar/c335f31e62b453f747f39a84240b3bbd'
   id: 443e9ca6ae16555ec9d336447aaac3a944eebf5b
+- name: TerranD7
+  role:
+    - Code
+    - Documentation
+  bio: FullStack Developer PHP/JS
+  location: Canada
+  github: terrance-orletsky-d7
+  title: Contributor
+  pic: 'https://www.gravatar.com/avatar/3767a002bed1270307c748df5a35a478'
+  id: bcbe4a9e7a9e4ed1e42fcb181966adfbffd6cd5d

--- a/docs/config/pantheon.md
+++ b/docs/config/pantheon.md
@@ -72,15 +72,22 @@ If you do not already have a [Landofile](./../config/lando.md) for your Pantheon
 
 Note that if the above config options are not enough, all Lando recipes can be further [extended and overriden](./../config/recipes.md#extending-and-overriding-recipes).
 
+### Using pantheon.local.yml
+
+If you would like to set different environment settings for your local Lando site vs the remote Pantheon site, you can create a `pantheon.local.yml` in the root of your repo, which will override / add to any settings in the `pantheon.yml` file.
+
+If you are using the same repo in multiple Lando environments (...with different Environment vars in `pantheon.local.yml`) then be sure to add the `pantheon.local.yml` file to your `.gitignore` file, and create a `pantheon.local.yml` in each environment's project folder
+
+
 ### Choosing a php version
 
-Lando will look for a [`pantheon.yml`](https://pantheon.io/docs/pantheon-yml/) (and/or `pantheon.upstream.yml`) in your app's root directory and use whatever `php_version` you've specified there.
+Lando will look for a [`pantheon.yml`](https://pantheon.io/docs/pantheon-yml/) (and/or `pantheon.upstream.yml` and/or `pantheon.local.yml`) in your app's root directory and use whatever `php_version` you've specified there.
 
 This means that **you can not configure the php version directly in your Landofile for this recipe.**
 
 If you change this version, make sure you [`lando rebuild`](./../cli/rebuild.md) for the changes to apply.
 
-**Example pantheon.yml**
+**Example pantheon.yml or pantheon.local.yml**
 
 ```yaml
 api_version: 1
@@ -89,7 +96,7 @@ php_version: 7.1
 
 ### Choosing a nested webroot
 
-Lando will look for a [`pantheon.yml`](https://pantheon.io/docs/pantheon-yml/) (and/or `pantheon.upstream.yml`) in your app's root directory and use whatever `web_docroot` you've specified there.
+Lando will look for a [`pantheon.yml`](https://pantheon.io/docs/pantheon-yml/) (and/or `pantheon.upstream.yml` and/or ` pantheon.local.yml`) in your app's root directory and use whatever `web_docroot` you've specified there.
 
 This means that **you cannot configure the webroot directly in your Landofile for this recipe.**
 
@@ -413,7 +420,7 @@ tika:
 
 ## Using Drush
 
-Lando will look for a [`pantheon.yml`](https://pantheon.io/docs/pantheon-yml/) (and/or `pantheon.upstream.yml`) in your app's root directory and will globally install whatever `drush_version` you've specified there. However, it will not go below Drush 8. This means that if you've specified Drush 5, Lando will still install Drush 8.
+Lando will look for a [`pantheon.yml`](https://pantheon.io/docs/pantheon-yml/) (and/or `pantheon.upstream.yml` and/or ` pantheon.local.yml`) in your app's root directory and will globally install whatever `drush_version` you've specified there. However, it will not go below Drush 8. This means that if you've specified Drush 5, Lando will still install Drush 8.
 
 If this has not been specified then we will globally install the [latest version of Drush 8](http://docs.drush.org/en/8.x/install/) unless you are running on `php 5.3` in which case we will install the [latest version of Drush 7](http://docs.drush.org/en/7.x/install/). For Backdrop sites, we will also install the latest version of [Backdrop Drush](https://github.com/backdrop-contrib/drush).
 
@@ -423,7 +430,7 @@ If you decide to list `drush` as a dependency in your project's `composer.json` 
 
 ### Configuring your root directory
 
-If you are using `web_docroot` in your `pantheon.yml`, you will need to remember to `cd` into that directory and run `lando drush` from there. This is because many site-specific `drush` commands will only run correctly if you run `drush` from a directory that also contains a Drupal site.
+If you are using `web_docroot` in your `pantheon.yml` or `pantheon.local.yml`, you will need to remember to `cd` into that directory and run `lando drush` from there. This is because many site-specific `drush` commands will only run correctly if you run `drush` from a directory that also contains a Drupal site.
 
 If you are annoyed by having to `cd` into that directory every time you run a `drush` command, you can get around it by [overriding](./../config/tooling.md#overriding) the `drush` tooling command in your [Landofile](./../config/lando.md) so that Drush always runs from your `webroot`.
 

--- a/examples/pantheon-drupal8/README.md
+++ b/examples/pantheon-drupal8/README.md
@@ -39,7 +39,7 @@ Run the following commands to validate things are rolling as they should.
 cd drupal8
 lando drush status | grep "Connected"
 
-# Should use the drush in pantheon.yml
+# Should use the drush in pantheon.yml or pantheon.local.yml
 cd drupal8
 lando drush version | grep 10.
 

--- a/examples/pantheon-wordpress/README.md
+++ b/examples/pantheon-wordpress/README.md
@@ -43,7 +43,7 @@ lando wp eval "phpinfo();"
 cd wordpress
 lando wp cli version
 
-# Should use custom webroot when set in pantheon.yml
+# Should use custom webroot when set in pantheon.yml or pantheon.local.yml
 cd wordpress
 lando ssh -s appserver -c "curl -L http://appserver_nginx" | grep "WordPress for Lando"
 lando ssh -s appserver -c "curl -kL https://appserver_nginx" | grep "WordPress for Lando"
@@ -65,7 +65,7 @@ lando composer --version | grep Composer | grep 1.10.1
 cd wordpress
 lando terminus auth:whoami | grep landobot@devwithlando.io
 
-# Should use custom php version if set in pantheon.yml
+# Should use custom php version if set in pantheon.yml or pantheon.local.yml
 cd wordpress
 lando php -v | grep "PHP 7.3"
 

--- a/examples/pantheon-wordpressnetworkdomain/README.md
+++ b/examples/pantheon-wordpressnetworkdomain/README.md
@@ -55,7 +55,7 @@ lando terminus -V
 cd wordpress
 lando terminus auth:whoami | grep landobot@devwithlando.io
 
-# Should use custom php version if set in pantheon.yml
+# Should use custom php version if set in pantheon.yml or pantheon.local.yml
 cd wordpress
 lando php -v | grep "PHP 7.3"
 

--- a/examples/pantheon-wordpressnetworkfolder/README.md
+++ b/examples/pantheon-wordpressnetworkfolder/README.md
@@ -55,7 +55,7 @@ lando terminus -V
 cd wordpress
 lando terminus auth:whoami | grep landobot@devwithlando.io
 
-# Should use custom php version if set in pantheon.yml
+# Should use custom php version if set in pantheon.yml or pantheon.local.yml
 cd wordpress
 lando php -v | grep "PHP 7.3"
 

--- a/integrations/lando-pantheon/lib/utils.js
+++ b/integrations/lando-pantheon/lib/utils.js
@@ -155,7 +155,7 @@ exports.getPantheonCache = () => ({
 /*
  * Helper to merge in pantheon yamls
  */
-exports.getPantheonConfig = (files = ['pantheon.upstream.yml', 'pantheon.yml']) => _(files)
+exports.getPantheonConfig = (files = ['pantheon.upstream.yml', 'pantheon.yml', 'pantheon.local.yml']) => _(files)
   .filter(file => fs.existsSync(file))
   .map(file => yaml.safeLoad(fs.readFileSync(file)))
   .thru(data => _.merge({}, ...data))

--- a/integrations/lando-pantheon/recipes/pantheon/builder.js
+++ b/integrations/lando-pantheon/recipes/pantheon/builder.js
@@ -93,6 +93,7 @@ module.exports = {
       options = _.merge({}, config, options, utils.getPantheonConfig([
         path.join(options.root, 'pantheon.upstream.yml'),
         path.join(options.root, 'pantheon.yml'),
+        path.join(options.root, 'pantheon.local.yml'),
       ]));
 
       // Normalize because 7.0 right away gets handled strangely by js-yaml


### PR DESCRIPTION
First time contributor - a bit unsure which steps to complete that are relevant to my changes - advice is most welcome, please

This PR adds support for a `pantheon.local.yml` file to override the settings in `pantheon.yml`, and `pantheon.upstream.yml`

This has become a requirement a couple times now, and creating scripting workarounds does not seem to be an efficient use of time.  This PR makes 'swapping' the pantheon.yml file in the local dev environment uneccessary, when an alternate config is needed.

This does not modify any other functionality

**Rationale:**  

As a team of developers we want to run our local Pantheon/Lando WP repo using an alternate configuration in our local Lando containers, as opposed to using the config for the Pantheon remote site (specified in `pantheon.yml`, and `pantheon.upstream.yml`), without having to create scripting to swap the files every time we commit/merge to master to deploy to Pantheon.

**Use case 1:** we want to *always* disable the Redis cache locally, but want to leave it enabled in the Pantheon remote, and want that config shared in the git repo amongst teammates

**Use Case 2:** we want to configure a repo to run a different version of PHP locally, for testing, and want that config shared in the git repo amongst teammates


- [x] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/help)
- [ ] My code includes a [functional test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes a [unit test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [x] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.



