### PR TITLE
Fixes #2934

### DIFF
--- a/docs/contrib/contrib-testing.md
+++ b/docs/contrib/contrib-testing.md
@@ -48,7 +48,7 @@ SORRY WINDOZE USERS!
 To generate tests from the `examples` repo and then run the functional test suite, execute the following:
 
 ```bash
-yarn generate-tests && yarn test:functional
+yarn generate:tests && yarn test:functional
 ```
 
 **NOTE:** This may take awhile to complete locally and could destroy any apps you may already have running. It's best to use it in a continuous integration environment.
@@ -68,7 +68,7 @@ Running the Lando functional tests can take a lot of system resources and in dev
 After editing or making a new test in one of the `example/*/README.md` files, you first need to regenerate the tests as follows:
 
 ```bash
-yarn generate-tests
+yarn generate:tests
 ```
 
 This will use `leia` to convert the `README.md` test steps into mocha functional tests in the `tests/` directory.

--- a/examples/drupal7/README.md
+++ b/examples/drupal7/README.md
@@ -71,6 +71,10 @@ cd drupal7
 lando ssh -s appserver -c "env" | grep SIMPLETEST_BASE_URL | grep "https://appserver"
 lando ssh -s appserver -c "env" | grep SIMPLETEST_DB | grep "mysql://drupal7:drupal7@database/drupal7"
 
+# Should have proxy urls present in lando info
+cd drupal7
+lando info |grep "lando-drupal7.lndo.site"
+
 # Should be able to pipe data directly into lando drush sql-cli
 cd drupal7
 lando db-export --stdout > dump.sql

--- a/plugins/lando-recipes/types/drupaly/builder.js
+++ b/plugins/lando-recipes/types/drupaly/builder.js
@@ -56,6 +56,8 @@ module.exports = {
         }
       }
 
+      options.proxy = _.merge({}, options.proxy);
+
       // Set legacy envars
       options.services = _.merge({}, options.services, {appserver: {overrides: {
         environment: {


### PR DESCRIPTION
In c1298b1b6444e0ce627e005484c750c53ac534cb we introduced a change to the laemp proxy config to allow for the Acquia recipe to inject proxy entries Mailhog. This caused standard Drupal recipes to not inject their own proxy. Other Laempy recipes did not seem to be affected in testing.