### PR TITLE
use LogLevel=FATAL to hide errors that are actually warnings

### DIFF
--- a/examples/keys/config
+++ b/examples/keys/config
@@ -2,5 +2,5 @@ Host *
   User "Han Solo"
   StrictHostKeyChecking no
   UserKnownHostsFile=/dev/null
-  LogLevel=ERROR
+  LogLevel=FATAL
   IdentityFile "/user/.ssh/smutkey1"

--- a/plugins/lando-core/scripts/load-keys.sh
+++ b/plugins/lando-core/scripts/load-keys.sh
@@ -118,7 +118,7 @@ Host *
   User "${LANDO_HOST_USER}"
   StrictHostKeyChecking no
   UserKnownHostsFile=/dev/null
-  LogLevel=ERROR
+  LogLevel=FATAL
 ${SSH_IDENTITIES[*]}
 EOF
 IFS="${OLDIFS}"


### PR DESCRIPTION
Resolves #2957

With setting `LogLevel=FATAL` the "errors" (which actually isn't an error, as the ssh connection still works) are not outputted by the ssh client.

- [x] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/help)
- [ ] My code includes a [functional test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes a [unit test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

