### PR TITLE
Use parse8 helper to set Solr 8.5 and 8.6 options

### DIFF
--- a/plugins/lando-services/services/solr/builder.js
+++ b/plugins/lando-services/services/solr/builder.js
@@ -107,6 +107,8 @@ const parseConfig = options => {
     case '3': return parse3(options);
     case '4.10': return parse4(options);
     case '4': return parse4(options);
+    case '8.6': return parse8(options);
+    case '8.5': return parse8(options);
     case '8.4': return parse8(options);
     case '8.3': return parse8(options);
     case '8.2': return parse8(options);


### PR DESCRIPTION
Possibly fixes #2866 

Issue #2866 seems to be caused by the wrong data directory being set, and that is adjusted using parse8 helper for Solr 8 versions.

I am not sure if there are other places to cover this as well, just spotted the probable cause while looking for a cause / workaround and thought it's at least a starting point.

- [x] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/help)
- [ ] My code includes a [functional test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes a [unit test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

