### PR TITLE
Updated acli to use the latest release instead of master

### DIFF
--- a/docs/config/acquia.md
+++ b/docs/config/acquia.md
@@ -63,7 +63,7 @@ Here are the configuration options, set to the default values, for this recipe. 
 ```yaml
 recipe: acquia
 config:
-  acli_version: master
+  acli_version: latest
   ah_application_uuid: null
   ah_site_group: null
   build:

--- a/experimental/lando-acquia/recipes/acquia/builder.js
+++ b/experimental/lando-acquia/recipes/acquia/builder.js
@@ -35,7 +35,7 @@ module.exports = {
       const keys = utils.sortKeys(options._app.acquiaKeys, options._app.hostKeys);
       // Try to grab other relevant stuff that we might have saved
       const account = _.get(options, '_app.meta.label', null);
-      const acliVersion = _.get(options, '_app.config.config.acli_version', 'master');
+      const acliVersion = _.get(options, '_app.config.config.acli_version', 'latest');
       const appUuid = _.get(options, '_app.config.config.ah_application_uuid', null);
       const group = _.get(options, '_app.config.config.ah_site_group', null);
       const key = _.get(options, '_app.meta.key', null);
@@ -44,7 +44,6 @@ module.exports = {
 
       // Figure out our ACLI situation first
       // Install acli from either 1) latest download, 2) A specific version, or 3) build from a branch
-      // TODO: switch default to `latest` once acli catches up.
       const regexVersion = /^[0-9]+\.[0-9]+\.[0-9]+$/g;
       let acliDownload = null;
       if (acliVersion === 'latest') {

--- a/experimental/lando-acquia/recipes/acquia/init.js
+++ b/experimental/lando-acquia/recipes/acquia/init.js
@@ -259,7 +259,7 @@ module.exports = {
         // Merge in other lando config
         const landofileConfig = {
           config: {
-            acli_version: 'master',
+            acli_version: 'latest',
             ah_application_uuid: options['acquia-app'],
             ah_site_group: env.group,
             php: env.php,


### PR DESCRIPTION
This PR updates the Acquia plugin to use the `latest` release of `acli` instead of building from the `master` branch.