### PR TITLE
Add Elasticsearch support to Lagoon Integration

### DIFF
--- a/docs/config/lagoon.md
+++ b/docs/config/lagoon.md
@@ -8,7 +8,7 @@ description: The best local development option for Lagoon a Docker Build and Dep
 
 This is currently an _beta_ level integration that has the following _serious caveats_:
 
-* This _does not_ support Lagoon's `elasticsearch`, `mongodb`, or `rabbitmq` containers yet
+* This _does not_ support Lagoon's `node`, `python` or `mongodb` containers yet
 * It's not yet clear how much customization to your project is currently supported
 
 However, if you'd like to try it out and give your feedback on what worked and what didn't then please continue.

--- a/docs/config/lagoon.md
+++ b/docs/config/lagoon.md
@@ -4,7 +4,7 @@ description: The best local development option for Lagoon a Docker Build and Dep
 
 # Lagoon **(beta)**
 
-[Lagoon](https://lagoon.readthedocs.io/en/latest/) solves what developers are dreaming about: A system that allows developers to locally develop their code and their services with Docker and run the exact same system in production. The same Docker images, the same service configurations and the same code.
+[Lagoon](https://docs.lagoon.sh/lagoon/) solves what developers are dreaming about: A system that allows developers to locally develop their code and their services with Docker and run the exact same system in production. The same Docker images, the same service configurations and the same code.
 
 This is currently an _beta_ level integration that has the following _serious caveats_:
 
@@ -113,7 +113,7 @@ config:
     - drush sql-sync my-database
 ```
 
-These will run against the [Lagoon PHP CLI Drupal container](https://lagoon.readthedocs.io/en/latest/using_lagoon/docker_images/php-cli-drupal/) so you will have access to all the tools there as well as the ones it inherits from the base [PHP CLI container](https://lagoon.readthedocs.io/en/latest/using_lagoon/docker_images/php-cli/).
+These will run against the [Lagoon PHP CLI Drupal container](https://docs.lagoon.sh/lagoon/docker-images/php-cli/php-cli-drupal) so you will have access to all the tools there as well as the ones it inherits from the base [PHP CLI container](https://docs.lagoon.sh/lagoon/docker-images/php-cli).
 
 Note that these will run the _first time_ you run `lando start`. You will need to run `lando rebuild` to trigger them again if you make changes.
 
@@ -127,14 +127,15 @@ Lando will read and interpret your normal `.lagoon.yml` and its associated Docke
 
 The services we currently support with links to their associated Lagoon docs is shown below:
 
-* [PHP-FPM](https://lagoon.readthedocs.io/en/latest/using_lagoon/docker_images/php-fpm/)
-* [PHP CLI](https://lagoon.readthedocs.io/en/latest/using_lagoon/docker_images/php-cli/)
-* [Nginx](https://lagoon.readthedocs.io/en/latest/using_lagoon/docker_images/nginx/)
-* [MariaDB](https://lagoon.readthedocs.io/en/latest/using_lagoon/docker_images/mariadb/)
-* [PostgreSQL](https://lagoon.readthedocs.io/en/latest/using_lagoon/docker_images/postgres/)
-* [Redis](https://lagoon.readthedocs.io/en/latest/using_lagoon/docker_images/redis/)
-* [Solr](https://lagoon.readthedocs.io/en/latest/using_lagoon/docker_images/solr/)
-* [Varnish](https://lagoon.readthedocs.io/en/latest/using_lagoon/docker_images/varnish/)
+* [Elasticsearch](https://docs.lagoon.sh/lagoon/docker-images/elasticsearch)
+* [PHP-FPM](https://docs.lagoon.sh/lagoon/docker-images/php-fpm)
+* [PHP CLI](https://docs.lagoon.sh/lagoon/docker-images/php-cli)
+* [Nginx](https://docs.lagoon.sh/lagoon/docker-images/nginx)
+* [MariaDB](https://docs.lagoon.sh/lagoon/docker-images/mariadb)
+* [PostgreSQL](https://docs.lagoon.sh/lagoon/docker-images/postgres)
+* [Redis](https://docs.lagoon.sh/lagoon/docker-images/redis)
+* [Solr](https://docs.lagoon.sh/lagoon/docker-images/solr)
+* [Varnish](https://docs.lagoon.sh/lagoon/docker-images/varnish)
 
 Note that we are testing against the "Drupal" variants of the above but it's _possible_ the base services work as well.
 

--- a/integrations/lando-lagoon/lib/services.js
+++ b/integrations/lando-lagoon/lib/services.js
@@ -14,6 +14,7 @@ const SQLServices = ['lagoon-mariadb', 'lagoon-postgres'];
  */
 const getLandoServiceType = type => {
   switch (type) {
+    case 'elasticsearch': return 'lagoon-elasticsearch';
     case 'nginx': return 'lagoon-nginx';
     case 'nginx-drupal': return 'lagoon-nginx';
     case 'none': return 'lagoon-none';

--- a/integrations/lando-lagoon/services/lagoon-elasticsearch/builder.js
+++ b/integrations/lando-lagoon/services/lagoon-elasticsearch/builder.js
@@ -1,0 +1,51 @@
+'use strict';
+
+// Modules
+const _ = require('lodash');
+
+// Builder
+module.exports = {
+  name: 'lagoon-elasticsearch',
+  config: {
+    version: 'custom',
+    confSrc: __dirname,
+    command: '/sbin/tini -- /lagoon/entrypoints.bash /usr/local/bin/docker-entrypoint.sh',
+    port: '9200',
+    portforward: true,
+    moreHttpPorts: ['9200'],
+  },
+  parent: '_lagoon',
+  builder: (parent, config) => class LandoLagoonElasticsearch extends parent {
+    constructor(id, options = {}, factory) {
+      options = _.merge({}, config, options);
+
+      // Set the meUser
+      options.meUser = 'elasticsearch';
+      // Ensure the non-root backup perm sweep runs
+      // NOTE: we guard against cases where the UID is the same as the bitnami non-root user
+      // because this messes things up on circle ci and presumably elsewhere and _should_ be unncessary
+      if (_.get(options, '_app._config.uid', '1000') !== '1001') options._app.nonRoot.push(options.name);
+
+      const elasticsearch = {
+        command: options.command,
+        ports: [options.port],
+        volumes: [
+          `${options.data}:/usr/share/elasticsearch/data`,
+        ],
+      };
+      // Add some lando info
+      options.info = _.merge({}, options.info, {
+        internal_connection: {
+          host: options.name,
+          port: options.port,
+        },
+        external_connection: {
+          host: options._app._config.bindAddress,
+          port: _.get(options, 'portforward', 'not forwarded'),
+        },
+      });
+      // Send it downstream
+      super(id, options, {services: _.set({}, options.name, elasticsearch)});
+    };
+  },
+};


### PR DESCRIPTION
This PR adds support for Elasticsearch to the Lagoon integration.

I have not provided tests in Lando for this integration (as it is very niche), but we will continue to test in the amazee.io examples for it.

I have updated the docs accordingly to reflect this (and other) service availability in Lando.

I have also updated our core documentation reference to https://docs.lagoon.sh

- [x] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/help)
- [ ] My code includes a [functional test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes a [unit test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [x] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [x] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

