### PR TITLE
Use PHP 7.4 for WordPress

### DIFF
--- a/docs/config/wordpress.md
+++ b/docs/config/wordpress.md
@@ -45,7 +45,7 @@ Here are the configuration options, set to the default values, for this recipe's
 ```yaml
 recipe: wordpress
 config:
-  php: '7.3'
+  php: '7.4'
   composer_version: '2.0.7'
   via: apache:2.4
   webroot: .

--- a/examples/wordpress/README.md
+++ b/examples/wordpress/README.md
@@ -33,9 +33,9 @@ Run the following commands to validate things are rolling as they should.
 cd wordpress
 lando ssh -s appserver -c "curl -L localhost" | grep "WordPress"
 
-# Should use 7.3 as the default php version
+# Should use 7.4 as the default php version
 cd wordpress
-lando php -v | grep "PHP 7.3"
+lando php -v | grep "PHP 7.4"
 
 # Should be running apache 2.4 by default
 cd wordpress

--- a/plugins/lando-recipes/recipes/wordpress/builder.js
+++ b/plugins/lando-recipes/recipes/wordpress/builder.js
@@ -5,13 +5,13 @@ const _ = require('lodash');
 const utils = require('./../../lib/utils');
 
 // WP status check
-const getWpStatusCheck = (version = '7.3') => {
+const getWpStatusCheck = (version = '7.4') => {
   if (version === '5.3') return ['true'];
   else return ['php', '/usr/local/bin/wp', '--info'];
 };
 
 // Helper to get WPCLI version
-const getWpCliUrl = (version = '7.3') => {
+const getWpCliUrl = (version = '7.4') => {
   if (version === '5.3') return 'https://github.com/wp-cli/wp-cli/releases/download/v1.5.1/wp-cli-1.5.1.phar';
   else return 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar';
 };
@@ -30,7 +30,7 @@ module.exports = {
     defaultFiles: {
       php: 'php.ini',
     },
-    php: '7.3',
+    php: '7.4',
     tooling: {wp: {service: 'appserver'}},
     via: 'apache',
     webroot: '.',


### PR DESCRIPTION
Closes #2929 

WordPress now recommends PHP 7.4: https://wordpress.org/about/requirements/

- [x] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/help)
- [ ] My code includes a [functional test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes a [unit test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [x] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

