### PR TITLE
Adds a notice about Xdebug triggers

### DIFF
--- a/docs/guides/lando-phpstorm.md
+++ b/docs/guides/lando-phpstorm.md
@@ -40,10 +40,10 @@ In the example above we set the variable to `appserver` and created a path mappi
 ![screenshot](/images/drush-xdebug-phpstorm.png)
 
 Depending on how you have configured Xdebug to be triggered (xdebug.start_with_request is off by default) 
-you will need to tell xdebug to start debugging the request by either setting that global option or by
-setting the following environment variable before your request:
+you will need to tell Xdebug to start debugging the request. You can do this by either setting that global
+option or by setting the following environment variable before running your request:
 ```
-XDEBUG_SESSION=PHPSTORM
+export XDEBUG_SESSION="PHPSTORM"
 ```
 
 <GuideFooter />

--- a/docs/guides/lando-phpstorm.md
+++ b/docs/guides/lando-phpstorm.md
@@ -39,5 +39,12 @@ In the example above we set the variable to `appserver` and created a path mappi
 
 ![screenshot](/images/drush-xdebug-phpstorm.png)
 
+Depending on how you have configured Xdebug to be triggered (xdebug.start_with_request is off by default) 
+you will need to tell xdebug to start debugging the request by either setting that global option or by
+setting the following environment variable before your request:
+```
+XDEBUG_SESSION=PHPSTORM
+```
+
 <GuideFooter />
 <Newsletter />


### PR DESCRIPTION
- [x] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/help)
- [ ] My code includes a [functional test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes a [unit test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [x] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

The guide on xdebug does not mention how to trigger it, this request adds a paragraph regarding that since it's easy to miss when trying to debug drush commands.

