### PR TITLE
Fixing a broken link.

### DIFF
--- a/docs/config/drupal9.md
+++ b/docs/config/drupal9.md
@@ -150,7 +150,7 @@ config:
 
 ### Using Drush
 
-As of Drupal 9 and Drush 10 it is preferred you use [a site-local install of Drush](https://www.drush.org/install/). For that reason Lando **will not** globall install a version of Drush for Drupal 9 sites.
+As of Drupal 9 and Drush 10 it is preferred you use [a site-local install of Drush](https://www.drush.org/latest/install/). For that reason Lando **will not** globall install a version of Drush for Drupal 9 sites.
 
 You can site-local install drush by requiring it in your projects `composer.json` file.
 


### PR DESCRIPTION
There was a bad link sending you to a 404 in the D9 documentation.

I can only assume this is the location it should be going to, since I can't see what the page used to say...