### PR TITLE
Update link to lagoon services

### DIFF
--- a/docs/config/lagoon.md
+++ b/docs/config/lagoon.md
@@ -96,7 +96,7 @@ services:
       << : *default-environment
 ```
 
-For the most up to date list of supported labels, check out [this](https://github.com/lando/lando/blob/master/integrations/lando-lagoon/lib/services.js#L15). To see labels in action check out the official [Amazee.io Drupal 9 Lagoon example](https://github.com/amazeeio/drupal-example-simple/blob/9.x/docker-compose.yml#L40).
+For the most up to date list of supported labels, check out [this](https://github.com/lando/cli/blob/main/integrations/lando-lagoon/lib/services.js#L15). To see labels in action check out the official [Amazee.io Drupal 9 Lagoon example](https://github.com/amazeeio/drupal-example-simple/blob/9.x/docker-compose.yml#L40).
 
 Also note that Lando additionally supports `lagoon.type === none` as documented over [here](https://docs.lagoon.sh/lagoon/using-lagoon-the-basics/docker-compose-yml#skip-ignore-containers).
 


### PR DESCRIPTION
The lagoon services file moved to `lando/cli` so the link needed updating.