### PR TITLE
Fixes #3129: Windows package was using Mac Docker Url

### DIFF
--- a/scripts/assemble-win.ps1
+++ b/scripts/assemble-win.ps1
@@ -15,7 +15,7 @@ $docker_version = $env:DOCKER_DESKTOP_VERSION
 $docker_build = $env:DOCKER_DESKTOP_BUILD
 
 # Download urls
-$docker_url="https://desktop.docker.com/mac/stable/amd64/$docker_build/Docker.dmg"
+$docker_url="https://desktop.docker.com/win/stable/amd64/$docker_build/Docker%20Desktop%20Installer.exe"
 $lando_url="https://files.lando.dev/cli/lando-win-x64-$lando_cli_version.exe"
 
 # Installer things


### PR DESCRIPTION
Windows installer was getting packaged with mac Docker installer. This fixes that.

Also, a note for future reference, the download path `https://desktop.docker.com/win/stable/...` will become `https://desktop.docker.com/win/main/...` starting with Docker Desktop 4.0.0