### PR TITLE
Update solr.md with jump-start instructions

### DIFF
--- a/docs/config/solr.md
+++ b/docs/config/solr.md
@@ -123,7 +123,7 @@ Note that if using custom configuration you can put your configuration files any
 
 ```bash
 ./
-|-- web/modules/contrib/search_api_solr/jump-start/solr7
+|-- web/modules/contrib/search_api_solr/jump-start/solr7/config-set
    |-- elevate.xml
    |-- mapping-ISOLatin1Accent.txt
    |-- protwords.txt
@@ -137,6 +137,7 @@ Note that if using custom configuration you can put your configuration files any
    |-- solrcore.properties
    |-- stopwords.txt
    |-- synonyms.txt
+   |-- ... (and many more)
 |-- .lando.yml
 ```
 
@@ -147,7 +148,7 @@ services:
   myservice:
     type: solr
     config:
-      dir: web/modules/contrib/search_api_solr/jump-start/solr7
+      dir: web/modules/contrib/search_api_solr/jump-start/solr7/config-set
 ```
 
 ## Getting information

--- a/docs/config/solr.md
+++ b/docs/config/solr.md
@@ -115,15 +115,15 @@ The `core` config value does not work for Solr 3.x or 4.x.
 
 You will almost certainly need to utilize your own custom Solr config. You can do that by telling Lando to inject solr config from a directory inside of your application.
 
-Consider a Drupal 8 application injecting the Solr 7.x config directly from the `search_api_solr` module as shown in the example below:
+Consider a Drupal 8 or 9 application injecting the Solr 7.x config directly from the `search_api_solr` module as shown in the example below:
 
 **A hypothetical project**
 
-Note that you can put your configuration files anywhere inside your application directory. We use a `config` directory but you can call it whatever you want such as `.lando` in the example below:
+Note that if using custom configuration you can put your configuration files anywhere inside your application directory. We use a `config` directory but you can call it whatever you want such as `.lando`. In this example we're using the ["jump-start" configuration](https://git.drupalcode.org/project/search_api_solr/-/tree/4.x/jump-start) from `search_api_solr`:
 
 ```bash
 ./
-|-- sites/all/modules/search_api_solr/solr-conf/7.x
+|-- web/modules/contrib/search_api_solr/jump-start/solr7
    |-- elevate.xml
    |-- mapping-ISOLatin1Accent.txt
    |-- protwords.txt
@@ -147,7 +147,7 @@ services:
   myservice:
     type: solr
     config:
-      dir: sites/all/modules/search_api_solr/solr-conf/7.x
+      dir: web/modules/contrib/search_api_solr/jump-start/solr7
 ```
 
 ## Getting information


### PR DESCRIPTION
This updates the solr docs with updated paths (`sites/all/modules` isn't where most folks store their code anymore) and also points to the [jump-start](https://www.drupal.org/project/search_api_solr/issues/3070455) config now available in search_api_solr 4.x.

Thanks for your consideration!

----------

Thank you so much for contributing code to Lando! If this is your **first time** contributing to Lando we recommend you first check our [Getting Involved](https://docs.lando.dev/contrib/contributing.html) docs.

It may also be useful to check the below documentation based on what you are trying to do:

* [Adding code to Lando](https://docs.lando.dev/contrib/contrib-intro.html)
* [Updating documentation](https://docs.lando.dev/contrib/contrib-intro.html)
* [Working on DevOps](https://docs.lando.dev/contrib/contrib-intro.html)
* [Working on Lando's auxiliary services eg websites, apis, etc](https://docs.lando.dev/contrib/contrib-intro.html)
* [Writing Lando Guides](https://docs.lando.dev/contrib/guides-intro.html)
* [Writing Lando blog posts](https://docs.lando.dev/contrib/blogging-intro.html)

We will get to your PR as soon as we can but in the meantime you might want to check to make sure you have done the following. **The more boxes you can check the easier it will be for us to merge in your changes with confidence**

- [x] My code includes the latest code from the `master` branch
- [ ] My code includes an update to the [CHANGELOG](https://github.com/lando/lando/tree/master/docs/help)
- [ ] My code includes a [functional test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [ ] My code includes a [unit test](https://docs.lando.dev/contrib/contrib-testing.html) if applicable
- [x] My code includes documentation updates if applicable.
- [ ] My code passes relevant CI status checks
- [ ] I have pinged [a project committer](https://docs.devwithlando.io/contrib/contributing.html#committers) when I think my code is ready for prime time.

