### PR TITLE
Minor typos

### DIFF
--- a/docs/basics/installation.md
+++ b/docs/basics/installation.md
@@ -60,7 +60,7 @@ We've found the below or better to deliver the best experience.
 <YouTube url="https://www.youtube.com/embed/W8qIutOAe-0" />
 
 ::: tip Do not fear the package size!
-Note that our macOS installer _includes_ Docker Desktop and this accounts for it's large file size in comparison to our Linux packages.
+Note that our macOS installer _includes_ Docker Desktop and this accounts for its large file size in comparison to our Linux packages.
 
 When going through the installer you can choose to _not_ install Docker Desktop, although we recommend you use the version of Docker Desktop that we ship for compatibility and support reasons!
 :::
@@ -171,7 +171,7 @@ Make sure that [Hyper-V is enabled](https://msdn.microsoft.com/en-us/virtualizat
 :::
 
 ::: tip Do not fear the package size!
-Note that our Windows installer _includes_ Docker Desktop and this accounts for it's large file size in comparison to our Linux packages.
+Note that our Windows installer _includes_ Docker Desktop and this accounts for its large file size in comparison to our Linux packages.
 
 When going through the installer you can choose to _not_ install Docker Desktop, although we recommend you use the version of Docker Desktop that we ship for compatibility and support reasons!
 :::

--- a/docs/config/drupal6.md
+++ b/docs/config/drupal6.md
@@ -79,7 +79,7 @@ config:
 You can set `composer_version` to any version that is available in our [php service](./php.md#installing-composer).
 
 ```yaml
-recipe: backdrop
+recipe: drupal6
 config:
   composer_version: '1.10.1'
 ```

--- a/docs/config/drupal7.md
+++ b/docs/config/drupal7.md
@@ -79,7 +79,7 @@ config:
 You can set `composer_version` to any version that is available in our [php service](./php.md#installing-composer).
 
 ```yaml
-recipe: backdrop
+recipe: drupal7
 config:
   composer_version: '1.10.1'
 ```

--- a/docs/config/joomla.md
+++ b/docs/config/joomla.md
@@ -77,7 +77,7 @@ config:
 You can set `composer_version` to any version that is available in our [php service](./php.md#installing-composer).
 
 ```yaml
-recipe: backdrop
+recipe: joomla
 config:
   composer_version: '1.10.1'
 ```

--- a/docs/config/lamp.md
+++ b/docs/config/lamp.md
@@ -81,7 +81,7 @@ config:
 You can set `composer_version` to any version that is available in our [php service](./php.md#installing-composer).
 
 ```yaml
-recipe: backdrop
+recipe: lamp
 config:
   composer_version: '1.10.1'
 ```

--- a/docs/config/laravel.md
+++ b/docs/config/laravel.md
@@ -80,7 +80,7 @@ config:
 You can set `composer_version` to any version that is available in our [php service](./php.md#installing-composer).
 
 ```yaml
-recipe: backdrop
+recipe: laravel
 config:
   composer_version: '1.10.1'
 ```
@@ -109,7 +109,7 @@ config:
 
 By default, this recipe will use the default version of our [mysql](./mysql.md) service as the database backend but you can also switch this to use [`mariadb`](./mariadb.md) or ['postgres'](./postgres.md) instead. Note that you can also specify a version *as long as it is a version available for use with lando* for either `mysql`, `mariadb` or `postgres`.
 
-If you are unsure about how to configure the `database`, we *highly recommend* you check out the [mysql](./mysql.md), [mariadb](./mariadb.md)and ['postgres'](./postgres.md) services before you change the default.
+If you are unsure about how to configure the `database`, we *highly recommend* you check out the [mysql](./mysql.md), [mariadb](./mariadb.md) and ['postgres'](./postgres.md) services before you change the default.
 
 Also note that like the configuration of the `php` version, you should consult the [Laravel requirements](https://laravel.com/docs/5.7/database#configuration) to make sure the `database` and `version` you select is actually supported by Laravel itself.
 

--- a/docs/config/lemp.md
+++ b/docs/config/lemp.md
@@ -81,7 +81,7 @@ config:
 You can set `composer_version` to any version that is available in our [php service](./php.md#installing-composer).
 
 ```yaml
-recipe: backdrop
+recipe: lemp
 config:
   composer_version: '1.10.1'
 ```

--- a/docs/config/wordpress.md
+++ b/docs/config/wordpress.md
@@ -76,7 +76,7 @@ config:
 You can set `composer_version` to any version that is available in our [php service](./php.md#installing-composer).
 
 ```yaml
-recipe: backdrop
+recipe: wordpress
 config:
   composer_version: '1.10.1'
 ```


### PR DESCRIPTION
There was a minor typo in the Laravel recipe documentation so I fixed it & updated a few other tiny typos/references (mostly the composer version config example had been copy/pasted from the ````backdrop```` recipe into all other docs without being updated to reflect the page's recipe).

Sorry if this is annoying, was just trying to tidy up as I read.