### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/ship-linux.yml
+++ b/.github/workflows/ship-linux.yml
@@ -9,8 +9,13 @@ on:
       - test*
       - v*
 
+permissions:
+  contents: read
+
 jobs:
   ship-linux-installer:
+    permissions:
+      contents: write  # for softprops/action-gh-release to create GitHub release
     runs-on: ${{ matrix.os }}
     env:
       TERM: xterm

--- a/.github/workflows/ship-macos.yml
+++ b/.github/workflows/ship-macos.yml
@@ -9,8 +9,13 @@ on:
       - test*
       - v*
 
+permissions:
+  contents: read
+
 jobs:
   ship-macos-installer:
+    permissions:
+      contents: write  # for softprops/action-gh-release to create GitHub release
     runs-on: ${{ matrix.os }}
     env:
       APPLE_CERT_DATA: ${{ secrets.APPLE_CERT_DATA }}

--- a/.github/workflows/ship-windoze.yml
+++ b/.github/workflows/ship-windoze.yml
@@ -8,8 +8,13 @@ on:
     tags:
       - test*
       - v*
+permissions:
+  contents: read
+
 jobs:
   ship-windows-installer:
+    permissions:
+      contents: write  # for softprops/action-gh-release to create GitHub release
     runs-on: ${{ matrix.os }}
     env:
       WINDOZE_CERT_DATA: ${{ secrets.WINDOZE_CERT_DATA }}

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -3,8 +3,13 @@ on:
   schedule:
     - cron: '8 14 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   auto-update-submodules:
+    permissions:
+      contents: write  # for Git to git push
     runs-on: ${{ matrix.os }}
     env:
       TERM: xterm


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
