### PR TITLE
Fix "introduction" link, so docs work

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Lando is and always will be FREE and OPEN SOURCE. As such it relies on generous 
 
 ### Getting Started
 
-[Introduction](https://docs.lando.dev/getting-started) | 
+[Introduction](https://docs.lando.dev/getting-started/) | 
 [CLI Usage](https://docs.lando.dev/cli/) | 
 [Installation](https://docs.lando.dev/getting-started/installation)
 


### PR DESCRIPTION
At present, if you click "Introduction" in the README.md it takes you to https://docs.lando.dev/getting-started. If you then read all the way down the page and click the "what-it-do.html" next link at the bottom, it will take you to https://docs.lando.dev/what-it-do.html which is a 404.

Adding a `/` makes that link take you to https://docs.lando.dev/getting-started/what-it-do.html instead, which works.

This fixes this one instance of this flow from the README.md page. However, a better fix would be to do one of the following:

a) Configure the sever to use redirects to always add the `/` to the end of directory URLs; or:  
b) Use absolute rather than relative links in the documentation navigation so it doesn't matter what the path of the origin page is.