### PR TITLE
Make windows installer messages suppressable

### DIFF
--- a/installer/win/Lando.iss
+++ b/installer/win/Lando.iss
@@ -122,14 +122,14 @@ begin
     end
     else begin
       Log('Windows feature VirtualMachinePlatform is not enabled');
-      MsgBox('Features not enabled!' + #13#10 + #13#10 + 'Lando requires that the VirtualMachinePlatform and Microsoft-Windows-Subsystem-Linux features be enabled.' + #13#10 + #13#10 + 'See https://learn.microsoft.com/en-us/windows/wsl/install for more info.', mbCriticalError, MB_OK);
+      SuppressibleMsgBox('Features not enabled!' + #13#10 + #13#10 + 'Lando requires that the VirtualMachinePlatform and Microsoft-Windows-Subsystem-Linux features be enabled.' + #13#10 + #13#10 + 'See https://learn.microsoft.com/en-us/windows/wsl/install for more info.', mbCriticalError, MB_OK);
       Result := False;
       Exit;
     end;
   end
   else begin
     Log('Could not determine status of  Windows Feature: VirtualMachinePlatform' + IntToStr(ErrorCode));
-    MsgBox('Could not determine status of  Windows Feature: VirtualMachinePlatform!', mbCriticalError, MB_OK);
+    SuppressibleMsgBox('Could not determine status of  Windows Feature: VirtualMachinePlatform!', mbCriticalError, MB_OK);
     Result := False;
     Exit;
   end;
@@ -143,14 +143,14 @@ begin
     end
     else begin
       Log('Windows feature Microsoft-Windows-Subsystem-Linux is not enabled');
-      MsgBox('Features not enabled!' + #13#10 + #13#10 + 'Lando requires that the VirtualMachinePlatform and Microsoft-Windows-Subsystem-Linux features be enabled.' + #13#10 + #13#10 + 'See https://learn.microsoft.com/en-us/windows/wsl/install for more info.', mbCriticalError, MB_OK);
+      SuppressibleMsgBox('Features not enabled!' + #13#10 + #13#10 + 'Lando requires that the VirtualMachinePlatform and Microsoft-Windows-Subsystem-Linux features be enabled.' + #13#10 + #13#10 + 'See https://learn.microsoft.com/en-us/windows/wsl/install for more info.', mbCriticalError, MB_OK);
       Result := False;
       Exit;
     end;
   end
   else begin
     Log('Could not determine status of  Windows Feature: Microsoft-Windows-Subsystem-Linux' + IntToStr(ErrorCode));
-    MsgBox('Could not determine status of  Windows Feature: Microsoft-Windows-Subsystem-Linux!', mbCriticalError, MB_OK);
+    SuppressibleMsgBox('Could not determine status of  Windows Feature: Microsoft-Windows-Subsystem-Linux!', mbCriticalError, MB_OK);
     Result := False;
     Exit;
   end;
@@ -207,7 +207,7 @@ begin
       if VersionComparison > 0 then
       begin
         Log('Host Docker Desktop version ahead of target. Component disabled.');
-        MsgBox('Newer Docker Desktop detected!' + #13#10 + #13#10 + 'The installer has detected that your version of Docker Desktop is ahead of what Lando expects!.' + #13#10 + #13#10 + 'This is probably ok but is technically unsupported so YMMV.', mbInformation, MB_OK);
+        SuppressibleMsgBox('Newer Docker Desktop detected!' + #13#10 + #13#10 + 'The installer has detected that your version of Docker Desktop is ahead of what Lando expects!.' + #13#10 + #13#10 + 'This is probably ok but is technically unsupported so YMMV.', mbInformation, MB_OK);
         WizardForm.ComponentsList.Checked[1] := False;
         WizardForm.ComponentsList.ItemEnabled[1] := False;
         WizardForm.ComponentsList.ItemCaption[1] := WizardForm.ComponentsList.ItemCaption[1] + ' (Already installed)';
@@ -222,14 +222,14 @@ begin
       if VersionComparison = -1 then
       begin
         Log('Host Docker Desktop version is behind target. Component enabled.');
-        MsgBox('Older Docker Desktop detected!' + #13#10 + #13#10 + 'The installer has detected an older version of Docker Desktop but we can update it for you!' + #13#10 + #13#10 + 'You can also skip its installation to proceed with your current version.', mbInformation, MB_OK);
+        SuppressibleMsgBox('Older Docker Desktop detected!' + #13#10 + #13#10 + 'The installer has detected an older version of Docker Desktop but we can update it for you!' + #13#10 + #13#10 + 'You can also skip its installation to proceed with your current version.', mbInformation, MB_OK);
         WizardForm.ComponentsList.Checked[1] := True;
         WizardForm.ComponentsList.ItemEnabled[1] := True;
       end;
     end
     else begin
       Log('Could not detect Docker Desktop!');
-      MsgBox('Docker Desktop not detected!' + #13#10 + #13#10 + 'The installer has detected that Docker Desktop is not installed but we can install it for you' + #13#10 + #13#10 + 'Make sure you have all the requirements to install' + #13#10 + 'See:  https://docs.docker.com/desktop/install/windows-install/#wsl-2-backend' + #13#10 + #13#10 + 'You can also skip its installation however it is required for Lando to work.', mbInformation, MB_OK);
+      SuppressibleMsgBox('Docker Desktop not detected!' + #13#10 + #13#10 + 'The installer has detected that Docker Desktop is not installed but we can install it for you' + #13#10 + #13#10 + 'Make sure you have all the requirements to install' + #13#10 + 'See:  https://docs.docker.com/desktop/install/windows-install/#wsl-2-backend' + #13#10 + #13#10 + 'You can also skip its installation however it is required for Lando to work.', mbInformation, MB_OK);
       WizardForm.ComponentsList.Checked[1] := True;
       WizardForm.ComponentsList.ItemEnabled[1] := True;
     end;


### PR DESCRIPTION
Unattended/scripted installations are currently impossible on Windows because message boxes are not suppressible. Msgboxes block the progress of scripted installations. This PR makes them suppressible.